### PR TITLE
Fix `SimulatorWebServiceAutoConfiguration.java`'s naming conventions.

### DIFF
--- a/simulator-samples/sample-bank-service/src/main/java/com/consol/citrus/simulator/sample/config/HttpClientConfig.java
+++ b/simulator-samples/sample-bank-service/src/main/java/com/consol/citrus/simulator/sample/config/HttpClientConfig.java
@@ -28,11 +28,9 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
 import javax.net.ssl.SSLContext;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.security.KeyManagementException;
@@ -55,8 +53,8 @@ public class HttpClientConfig {
     @Value("${server.ssl.key-password}")
     private String keyPassword;
 
-    @Bean(name = "simulatorHttpClientEndpoint")
-    public HttpClient clientEndpoint() {
+    @Bean
+    public HttpClient simulatorHttpClientEndpoint() {
         return CitrusEndpoints.http()
                 .client()
                 .timeout(defaultTimeout)

--- a/simulator-samples/sample-jms-fax/src/main/java/com/consol/citrus/simulator/sample/jms/async/Simulator.java
+++ b/simulator-samples/sample-jms-fax/src/main/java/com/consol/citrus/simulator/sample/jms/async/Simulator.java
@@ -58,8 +58,8 @@ public class Simulator extends SimulatorJmsAdapter {
                 .addXPathExpression("//fax:clientId");
     }
 
-    @Bean(name = "simulatorJmsStatusEndpoint")
-    public JmsEndpoint statusEndpoint() {
+    @Bean
+    public JmsEndpoint simulatorJmsStatusEndpoint() {
         return CitrusEndpoints.jms()
                 .asynchronous()
                 .destination(statusDestinationName)

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/endpoint/SimulatorEndpointAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/endpoint/SimulatorEndpointAutoConfiguration.java
@@ -46,7 +46,7 @@ public class SimulatorEndpointAutoConfiguration {
     @Autowired
     private SimulatorConfigurationProperties simulatorConfiguration;
 
-    @Bean(name = "simulatorEndpoint")
+    @Bean
     protected Endpoint simulatorEndpoint(ApplicationContext applicationContext) {
         if (configurer != null) {
             return configurer.endpoint(applicationContext);
@@ -59,12 +59,12 @@ public class SimulatorEndpointAutoConfiguration {
         }
     }
 
-    @Bean(name = "simulatorEndpointAdapter")
+    @Bean
     public SimulatorEndpointAdapter simulatorEndpointAdapter() {
         return new SimulatorEndpointAdapter();
     }
 
-    @Bean(name = "simulatorScenarioMapper")
+    @Bean
     public ScenarioMapper simulatorScenarioMapper() {
         if (configurer != null) {
             return configurer.scenarioMapper();
@@ -73,8 +73,8 @@ public class SimulatorEndpointAutoConfiguration {
         return new ContentBasedXPathScenarioMapper().addXPathExpression("local-name(/*)");
     }
 
-    @Bean(name = "simulatorEndpointPoller")
-    public SimulatorEndpointPoller endpointPoller(ApplicationContext applicationContext) {
+    @Bean
+    public SimulatorEndpointPoller simulatorEndpointPoller(ApplicationContext applicationContext) {
         SimulatorEndpointPoller endpointPoller;
 
         if (configurer != null && configurer.useSoapEnvelope()) {
@@ -96,7 +96,7 @@ public class SimulatorEndpointAutoConfiguration {
         return endpointPoller;
     }
 
-    @Bean(name = "simulatorFallbackEndpointAdapter")
+    @Bean
     public EndpointAdapter simulatorFallbackEndpointAdapter() {
         if (configurer != null) {
             return configurer.fallbackEndpointAdapter();

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorRestAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorRestAutoConfiguration.java
@@ -95,8 +95,8 @@ public class SimulatorRestAutoConfiguration {
         return filterRegistrationBean;
     }
 
-    @Bean(name = "simulatorRestHandlerMapping")
-    public HandlerMapping handlerMapping(ApplicationContext applicationContext) {
+    @Bean
+    public HandlerMapping simulatorRestHandlerMapping(ApplicationContext applicationContext) {
         SimpleUrlHandlerMapping handlerMapping = new SimpleUrlHandlerMapping();
         handlerMapping.setOrder(Ordered.HIGHEST_PRECEDENCE);
         handlerMapping.setAlwaysUseFullPath(true);
@@ -110,8 +110,8 @@ public class SimulatorRestAutoConfiguration {
         return handlerMapping;
     }
 
-    @Bean(name = "simulatorRestHandlerAdapter")
-    public HandlerAdapter handlerAdapter(final ApplicationContext applicationContext) {
+    @Bean
+    public HandlerAdapter simulatorRestHandlerAdapter(final ApplicationContext applicationContext) {
         final RequestMappingHandlerMapping handlerMapping = new RequestMappingHandlerMapping() {
             @Override
             protected void initHandlerMethods() {
@@ -144,13 +144,13 @@ public class SimulatorRestAutoConfiguration {
         };
     }
 
-    @Bean(name = "simulatorRestEndpointAdapter")
-    public SimulatorEndpointAdapter simulatorEndpointAdapter() {
+    @Bean
+    public SimulatorEndpointAdapter simulatorRestEndpointAdapter() {
         return new SimulatorEndpointAdapter();
     }
 
-    @Bean(name = "simulatorRestFallbackEndpointAdapter")
-    public EndpointAdapter simulatorFallbackEndpointAdapter() {
+    @Bean
+    public EndpointAdapter simulatorRestFallbackEndpointAdapter() {
         if (configurer != null) {
             return configurer.fallbackEndpointAdapter();
         }
@@ -168,10 +168,10 @@ public class SimulatorRestAutoConfiguration {
         if (restController == null) {
             restController = new HttpMessageController();
 
-            SimulatorEndpointAdapter endpointAdapter = simulatorEndpointAdapter();
+            SimulatorEndpointAdapter endpointAdapter = simulatorRestEndpointAdapter();
             endpointAdapter.setApplicationContext(applicationContext);
-            endpointAdapter.setMappingKeyExtractor(simulatorScenarioMapper());
-            endpointAdapter.setFallbackEndpointAdapter(simulatorFallbackEndpointAdapter());
+            endpointAdapter.setMappingKeyExtractor(simulatorRestScenarioMapper());
+            endpointAdapter.setFallbackEndpointAdapter(simulatorRestFallbackEndpointAdapter());
 
             restController.setEndpointAdapter(endpointAdapter);
         }
@@ -179,8 +179,8 @@ public class SimulatorRestAutoConfiguration {
         return restController;
     }
 
-    @Bean(name = "simulatorRestScenarioMapper")
-    public ScenarioMapper simulatorScenarioMapper() {
+    @Bean
+    public ScenarioMapper simulatorRestScenarioMapper() {
         if (configurer != null) {
             return configurer.scenarioMapper();
         }
@@ -194,10 +194,10 @@ public class SimulatorRestAutoConfiguration {
         return new InterceptorHttp(messageListeners);
     }
 
-    @Bean(name = "simulatorRestScenarioGenerator")
+    @Bean
     @ConditionalOnMissingBean(HttpScenarioGenerator.class)
     @ConditionalOnProperty(prefix = "citrus.simulator.rest.swagger", value = "enabled", havingValue = "true")
-    public static HttpScenarioGenerator scenarioGenerator(Environment environment) {
+    public static HttpScenarioGenerator simulatorRestScenarioGenerator(Environment environment) {
         return new HttpScenarioGenerator(environment);
     }
 

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/jms/SimulatorJmsAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/jms/SimulatorJmsAutoConfiguration.java
@@ -62,8 +62,8 @@ public class SimulatorJmsAutoConfiguration {
         return new SingleConnectionFactory();
     }
 
-    @Bean(name = "simulatorJmsInboundEndpoint")
-    protected JmsEndpoint jmsInboundEndpoint(ConnectionFactory connectionFactory) {
+    @Bean
+    protected JmsEndpoint simulatorJmsInboundEndpoint(ConnectionFactory connectionFactory) {
         if (isSynchronous()) {
             JmsSyncEndpointConfiguration endpointConfiguration = new JmsSyncEndpointConfiguration();
             JmsSyncEndpoint jmsEndpoint = new JmsSyncEndpoint(endpointConfiguration);
@@ -86,13 +86,13 @@ public class SimulatorJmsAutoConfiguration {
         }
     }
 
-    @Bean(name = "simulatorJmsEndpointAdapter")
-    public SimulatorEndpointAdapter simulatorEndpointAdapter() {
+    @Bean
+    public SimulatorEndpointAdapter simulatorJmsEndpointAdapter() {
         return new SimulatorEndpointAdapter();
     }
 
-    @Bean(name = "simulatorJmsScenarioMapper")
-    public ScenarioMapper simulatorScenarioMapper() {
+    @Bean
+    public ScenarioMapper simulatorJmsScenarioMapper() {
         if (configurer != null) {
             return configurer.scenarioMapper();
         }
@@ -100,8 +100,8 @@ public class SimulatorJmsAutoConfiguration {
         return new ContentBasedXPathScenarioMapper().addXPathExpression("local-name(/*)");
     }
 
-    @Bean(name = "simulatorJmsEndpointPoller")
-    public SimulatorEndpointPoller endpointPoller(ApplicationContext applicationContext,
+    @Bean
+    public SimulatorEndpointPoller simulatorJmsEndpointPoller(ApplicationContext applicationContext,
                                                   ConnectionFactory connectionFactory) {
         SimulatorEndpointPoller endpointPoller;
 
@@ -111,12 +111,12 @@ public class SimulatorJmsAutoConfiguration {
             endpointPoller = new SimulatorEndpointPoller();
         }
 
-        endpointPoller.setInboundEndpoint(jmsInboundEndpoint(connectionFactory));
+        endpointPoller.setInboundEndpoint(simulatorJmsInboundEndpoint(connectionFactory));
 
-        SimulatorEndpointAdapter endpointAdapter = simulatorEndpointAdapter();
+        SimulatorEndpointAdapter endpointAdapter = simulatorJmsEndpointAdapter();
         endpointAdapter.setApplicationContext(applicationContext);
-        endpointAdapter.setMappingKeyExtractor(simulatorScenarioMapper());
-        endpointAdapter.setFallbackEndpointAdapter(simulatorFallbackEndpointAdapter());
+        endpointAdapter.setMappingKeyExtractor(simulatorJmsScenarioMapper());
+        endpointAdapter.setFallbackEndpointAdapter(simulatorJmsFallbackEndpointAdapter());
 
         if (!isSynchronous()) {
             endpointAdapter.setHandleResponse(false);
@@ -129,8 +129,8 @@ public class SimulatorJmsAutoConfiguration {
         return endpointPoller;
     }
 
-    @Bean(name = "simulatorJmsFallbackEndpointAdapter")
-    public EndpointAdapter simulatorFallbackEndpointAdapter() {
+    @Bean
+    public EndpointAdapter simulatorJmsFallbackEndpointAdapter() {
         if (configurer != null) {
             return configurer.fallbackEndpointAdapter();
         }

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/ws/SimulatorWebServiceAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/ws/SimulatorWebServiceAutoConfiguration.java
@@ -68,44 +68,44 @@ public class SimulatorWebServiceAutoConfiguration {
     }
 
     @Bean
-    public ServletRegistrationBean messageDispatcherServlet(ApplicationContext applicationContext) {
+    public ServletRegistrationBean<MessageDispatcherServlet> simulatorServletRegistrationBean(ApplicationContext applicationContext) {
         MessageDispatcherServlet servlet = new MessageDispatcherServlet();
         servlet.setApplicationContext(applicationContext);
         servlet.setTransformWsdlLocations(true);
         return new ServletRegistrationBean<>(servlet, getServletMapping());
     }
 
-    @Bean(name = "simulatorWsEndpointMapping")
-    public EndpointMapping endpointMapping(ApplicationContext applicationContext) {
+    @Bean
+    public EndpointMapping simulatorWsEndpointMapping(ApplicationContext applicationContext) {
         UriEndpointMapping endpointMapping = new UriEndpointMapping();
         endpointMapping.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
-        endpointMapping.setDefaultEndpoint(webServiceEndpoint(applicationContext));
+        endpointMapping.setDefaultEndpoint(simulatorWsEndpoint(applicationContext));
         endpointMapping.setInterceptors(interceptors());
 
         return endpointMapping;
     }
 
-    @Bean(name = "simulatorWsEndpoint")
-    public MessageEndpoint webServiceEndpoint(ApplicationContext applicationContext) {
+    @Bean
+    public MessageEndpoint simulatorWsEndpoint(ApplicationContext applicationContext) {
         WebServiceEndpoint webServiceEndpoint = new WebServiceEndpoint();
-        SimulatorEndpointAdapter endpointAdapter = simulatorEndpointAdapter();
+        SimulatorEndpointAdapter endpointAdapter = simulatorWsEndpointAdapter();
         endpointAdapter.setApplicationContext(applicationContext);
-        endpointAdapter.setMappingKeyExtractor(simulatorScenarioMapper());
-        endpointAdapter.setFallbackEndpointAdapter(simulatorFallbackEndpointAdapter());
+        endpointAdapter.setMappingKeyExtractor(simulatorWsScenarioMapper());
+        endpointAdapter.setFallbackEndpointAdapter(simulatorWsFallbackEndpointAdapter());
 
         webServiceEndpoint.setEndpointAdapter(endpointAdapter);
 
         return webServiceEndpoint;
     }
 
-    @Bean(name = "simulatorWsEndpointAdapter")
-    public SimulatorEndpointAdapter simulatorEndpointAdapter() {
+    @Bean
+    public SimulatorEndpointAdapter simulatorWsEndpointAdapter() {
         return new SimulatorEndpointAdapter();
     }
 
-    @Bean(name = "simulatorWsScenarioMapper")
-    public ScenarioMapper simulatorScenarioMapper() {
+    @Bean
+    public ScenarioMapper simulatorWsScenarioMapper() {
         if (configurer != null) {
             return configurer.scenarioMapper();
         }
@@ -113,8 +113,8 @@ public class SimulatorWebServiceAutoConfiguration {
         return new ContentBasedXPathScenarioMapper().addXPathExpression("local-name(/*)");
     }
 
-    @Bean(name = "simulatorWsFallbackEndpointAdapter")
-    public EndpointAdapter simulatorFallbackEndpointAdapter() {
+    @Bean
+    public EndpointAdapter simulatorWsFallbackEndpointAdapter() {
         if (configurer != null) {
             return configurer.fallbackEndpointAdapter();
         }
@@ -122,10 +122,10 @@ public class SimulatorWebServiceAutoConfiguration {
         return new EmptyResponseEndpointAdapter();
     }
 
-    @Bean(name = "simulatorWsdlScenarioGenerator")
+    @Bean
     @ConditionalOnMissingBean(WsdlScenarioGenerator.class)
     @ConditionalOnProperty(prefix = "citrus.simulator.ws.wsdl", value = "enabled", havingValue = "true")
-    public static WsdlScenarioGenerator scenarioGenerator(Environment environment) {
+    public static WsdlScenarioGenerator simulatorWsdlScenarioGenerator(Environment environment) {
         return new WsdlScenarioGenerator(environment);
     }
 

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/ws/SimulatorWebServiceClientAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/ws/SimulatorWebServiceClientAutoConfiguration.java
@@ -50,8 +50,8 @@ public class SimulatorWebServiceClientAutoConfiguration {
     @Autowired
     private SimulatorWebServiceClientConfigurationProperties simulatorConfiguration;
 
-    @Bean(name = "simulatorWsClientEndpoint")
-    public WebServiceClient webServiceClientEndpoint() {
+    @Bean
+    public WebServiceClient simulatorWsClientEndpoint() {
         WebServiceClient endpoint = new WebServiceClient();
         endpoint.getEndpointConfiguration().setDefaultUri(getRequestUrl());
         endpoint.getEndpointConfiguration().setMessageFactory(getMessageFactory());


### PR DESCRIPTION
Fix for the "bean-overriding" bug, reported in #15 ..

The following bean was registered by Citrus-Simulator:
```java
com.consol.citrus.simulator.ws.SimulatorWebServiceAutoConfiguration {
[...]
public ServletRegistrationBean messageDispatcherServlet (
[...]
```
which conflicted with Spring Boot's autoconfiguration (`spring-boot-autoconfiguration`):
```java
org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration {
[...]
public ServletRegistrationBean<MessageDispatcherServlet> messageDispatcherServlet (
[...]
```
Therefore the Citrus-Simulator bean is now named `simulatorServletRegistrationBean` and those beans can co-exist.