### PR TITLE
Skip ITs for main project build w/o Sonarqube

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 if [ "${SONAR_SCANNER_HOME}" != "" ]; then
     COMMAND="mvn --batch-mode -q -Pskip-it clean org.jacoco:jacoco-maven-plugin:prepare-agent install -Dembedded sonar:sonar -Dsonar.projectKey=citrus-simulator"
 else
-    COMMAND="mvn --batch-mode -q clean install"
+    COMMAND="mvn --batch-mode -q -Pskip-it clean install"
 fi
 
 echo ${COMMAND}


### PR DESCRIPTION
The "main" build skips integration tests, since those are executed separately in subsequent steps. If the Sonar env is not available, integration tests should be skipped as well.