### PR TITLE
Fixed http message converters after update to Spring 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ jobs:
   - stage: sample-rest
     script:
     - mvn -f simulator-samples/sample-rest/pom.xml verify
+  - stage: sample-swagger
+    script:
+    - mvn -f simulator-samples/sample-swagger/pom.xml verify
   - stage: sample-ws
     script:
     - mvn -f simulator-samples/sample-ws/pom.xml verify

--- a/simulator-samples/pom.xml
+++ b/simulator-samples/pom.xml
@@ -25,7 +25,7 @@
   <modules>
     <module>sample-bank-service</module>
     <module>sample-rest</module>
-    <!--module>sample-swagger</module-->
+    <module>sample-swagger</module>
     <module>sample-ws</module>
     <module>sample-ws-client</module>
     <module>sample-wsdl</module>

--- a/simulator-samples/sample-swagger/src/test/java/com/consol/citrus/simulator/SimulatorRestIT.java
+++ b/simulator-samples/sample-swagger/src/test/java/com/consol/citrus/simulator/SimulatorRestIT.java
@@ -21,6 +21,7 @@ import com.consol.citrus.dsl.testng.TestNGCitrusTestDesigner;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.message.MessageType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,7 +35,56 @@ public class SimulatorRestIT extends TestNGCitrusTestDesigner {
 
     /** Test Http REST client */
     @Autowired
+    @Qualifier("petstoreClient")
     private HttpClient petstoreClient;
+
+    /** Client to access simulator user interface */
+    @Autowired
+    @Qualifier("simulatorUiClient")
+    private HttpClient simulatorUiClient;
+
+    @CitrusTest
+    public void testUiInfo() {
+        http().client(simulatorUiClient)
+                .send()
+                .get("/api/manage/info")
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        http().client(simulatorUiClient)
+                .receive()
+                .response(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .payload("{" +
+                        "\"simulator\":" +
+                            "{" +
+                                "\"name\":\"REST Petstore Simulator\"," +
+                                "\"version\":\"@ignore@\"" +
+                            "}" +
+                        "}");
+    }
+
+    @CitrusTest
+    public void testUiSummaryResults() {
+        http().client(simulatorUiClient)
+                .send()
+                .get("/api/summary/results")
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        http().client(simulatorUiClient)
+                .receive()
+                .response(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .payload("{" +
+                            "\"size\":\"@isNumber()@\"," +
+                            "\"failed\":\"@isNumber()@\"," +
+                            "\"success\":\"@isNumber()@\"," +
+                            "\"skipped\":0," +
+                            "\"skippedPercentage\":\"0.0\"," +
+                            "\"failedPercentage\":\"@ignore@\"," +
+                            "\"successPercentage\":\"@ignore@\"}");
+    }
 
     @CitrusTest
     public void testAddPet() {
@@ -158,7 +208,7 @@ public class SimulatorRestIT extends TestNGCitrusTestDesigner {
                 .receive()
                 .response(HttpStatus.OK);
     }
-    
+
     @CitrusTest
     public void testLoginUser() {
         http().client(petstoreClient)

--- a/simulator-samples/sample-swagger/src/test/resources/citrus-context.xml
+++ b/simulator-samples/sample-swagger/src/test/resources/citrus-context.xml
@@ -9,8 +9,14 @@
 
   <!-- Test Http REST client -->
   <citrus-http:client
-      id="simulatorClient"
+      id="petstoreClient"
       request-url="http://localhost:8080/petstore/v2"
+      timeout="5000"
+  />
+
+  <citrus-http:client
+      id="simulatorUiClient"
+      request-url="http://localhost:8080/"
       timeout="5000"
   />
 

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorHttpMessageConverter.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorHttpMessageConverter.java
@@ -1,0 +1,74 @@
+package com.consol.citrus.simulator.http;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import com.consol.citrus.http.controller.HttpMessageController;
+import com.consol.citrus.http.message.DelegatingHttpEntityMessageConverter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+/**
+ * Special generic message converter only applies to {@link HttpMessageController} context class when reading data.
+ * If context class is different than that default Spring internal message converters should apply. This makes sure that all
+ * simulator related requests are handled by the {@link DelegatingHttpEntityMessageConverter} for future processing in Citrus.
+ *
+ * All other requests should be converted by conventional Spring converters for normal MVC processing.
+ *
+ * @author Christoph Deppisch
+ */
+@SuppressWarnings("NullableProblems")
+public class SimulatorHttpMessageConverter implements GenericHttpMessageConverter<Object> {
+
+    private final DelegatingHttpEntityMessageConverter delegate = new DelegatingHttpEntityMessageConverter();
+
+    @Override
+    public boolean canRead(Type type, Class contextClass, MediaType mediaType) {
+        return HttpMessageController.class.equals(contextClass);
+    }
+
+    @Override
+    public Object read(Type type, Class contextClass, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        return delegate.read(Object.class, inputMessage);
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public void write(Object o, Type type, MediaType contentType, HttpOutputMessage outputMessage) throws HttpMessageNotWritableException {
+        throw new IllegalStateException("Illegal write operation on simulator message converter.");
+    }
+
+    @Override
+    public boolean canRead(Class clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Class clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public List<MediaType> getSupportedMediaTypes() {
+        return delegate.getSupportedMediaTypes();
+    }
+
+    @Override
+    public Object read(Class clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        throw new IllegalStateException("Illegal read operation on simulator message converter.");
+    }
+
+    @Override
+    public void write(Object o, MediaType contentType, HttpOutputMessage outputMessage) throws HttpMessageNotWritableException {
+        throw new IllegalStateException("Illegal write operation on simulator message converter.");
+    }
+}

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorRestAutoConfiguration.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/http/SimulatorRestAutoConfiguration.java
@@ -16,6 +16,14 @@
 
 package com.consol.citrus.simulator.http;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.consol.citrus.endpoint.EndpointAdapter;
 import com.consol.citrus.endpoint.adapter.EmptyResponseEndpointAdapter;
 import com.consol.citrus.http.controller.HttpMessageController;
@@ -47,10 +55,6 @@ import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.*;
 
 /**
  * @author Christoph Deppisch
@@ -128,6 +132,7 @@ public class SimulatorRestAutoConfiguration {
         handlerMapping.setApplicationContext(applicationContext);
         handlerMapping.afterPropertiesSet();
 
+        requestMappingHandlerAdapter.getMessageConverters().add(0, new SimulatorHttpMessageConverter());
         requestMappingHandlerAdapter.getMessageConverters().add(new DelegatingHttpEntityMessageConverter());
         requestMappingHandlerAdapter.setCacheSeconds(0);
 

--- a/simulator-starter/src/main/resources/META-INF/citrus-simulator.properties
+++ b/simulator-starter/src/main/resources/META-INF/citrus-simulator.properties
@@ -28,8 +28,7 @@ spring.resources.chain.enabled=true
 spring.resources.static-locations=classpath:/static/dist/,classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/
 
 # actuator properties
-management.context-path=/api/manage
-endpoints.sensitive=false
+management.endpoints.web.base-path=/api/manage
 
 # Properties for the about page
 info.simulator.name=Citrus Simulator

--- a/simulator-starter/src/test/java/com/consol/citrus/simulator/http/SimulatorHttpMessageConverterTest.java
+++ b/simulator-starter/src/test/java/com/consol/citrus/simulator/http/SimulatorHttpMessageConverterTest.java
@@ -1,0 +1,45 @@
+package com.consol.citrus.simulator.http;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import com.consol.citrus.http.controller.HttpMessageController;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.http.MockHttpOutputMessage;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SimulatorHttpMessageConverterTest {
+
+    private SimulatorHttpMessageConverter converter = new SimulatorHttpMessageConverter();
+
+    @Test
+    public void testSimulatorMessageConverter() throws IOException {
+        Assert.assertFalse(converter.canRead(Object.class, Object.class, MediaType.ALL));
+        Assert.assertFalse(converter.canRead(Object.class, MediaType.ALL));
+        Assert.assertFalse(converter.canWrite(Object.class, Object.class, MediaType.ALL));
+        Assert.assertFalse(converter.canWrite(Object.class, MediaType.ALL));
+
+        Assert.assertEquals(converter.read(String.class, HttpMessageController.class, new MockHttpInputMessage("Hello".getBytes(Charset.forName("UTF-8")))), "Hello");
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testUnsupportedRead() throws IOException {
+        converter.read(Object.class, new MockHttpInputMessage("Hello".getBytes(Charset.forName("UTF-8"))));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testUnsupportedWrite() {
+        converter.write("Hello", MediaType.TEXT_PLAIN, new MockHttpOutputMessage());
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testUnsupportedGenericWrite() {
+        converter.write("Hello", String.class, MediaType.TEXT_PLAIN, new MockHttpOutputMessage());
+    }
+
+}

--- a/simulator-ui/src/main/resources/static/package-lock.json
+++ b/simulator-ui/src/main/resources/static/package-lock.json
@@ -518,7 +518,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
@@ -1779,8 +1778,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2277,8 +2275,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "denodeify": {
       "version": "1.2.1",
@@ -3476,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
@@ -3679,10 +3675,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "neo-async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.1.8"
       },
       "dependencies": {
         "source-map": {
@@ -3771,8 +3767,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hash-base": {
       "version": "2.0.2",
@@ -5957,7 +5952,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -6078,8 +6072,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -9969,7 +9963,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "1.0.2"
       }


### PR DESCRIPTION
- Add special simulator message converter delegating to Citrus message converter
- Reactivate Swagger samples (were failing because of that issue)
- Make sure simulator UI api calls are fine, too
- Fix api management info endpoint URI