### PR TITLE
chore: Bump dependency versions to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.10.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.9.RELEASE")
     }
 }
 
@@ -97,7 +97,7 @@ When choosing Maven as build tool the pom file is a normal Spring Boot project w
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <citrus.simulator.version>1.1.0-SNAPSHOT</citrus.simulator.version>
-    <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
+    <spring.boot.version>2.0.9.RELEASE</spring.boot.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,19 +18,19 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <citrus.version>2.8.0</citrus.version>
-    <spring.version>5.0.7.RELEASE</spring.version>
-    <spring.ws.version>3.0.1.RELEASE</spring.ws.version>
-    <spring.boot.version>2.0.4.RELEASE</spring.boot.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <spring.version>5.0.15.RELEASE</spring.version>
+    <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
+    <spring.boot.version>2.0.9.RELEASE</spring.boot.version>
+    <slf4j.version>1.7.28</slf4j.version>
     <logback.classic.version>1.2.3</logback.classic.version>
     <testng.version>6.14.3</testng.version>
-    <lombok.version>1.18.0</lombok.version>
+    <lombok.version>1.18.8</lombok.version>
 
     <javadoc.options>-Xdoclint:none</javadoc.options>
 
     <node.version>v8.9.1</node.version>
     <npm.version>5.5.1</npm.version>
-    
+
     <skip.gpg>false</skip.gpg>
     <reuseForks>true</reuseForks>
   </properties>
@@ -347,7 +347,7 @@
             </execution>
           </executions>
         </plugin>
-        
+
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version>


### PR DESCRIPTION
Uses the latest Spring versions that are compatible with those used in Citrus core framework. Using even newer versions might lead to runtime errors because Citrus core framework is not supporting those versions.

Versions used now are Spring 5.0.15 and Spring Boot 2.0.9