### PR TITLE
Use Spring Boot 2.0 for the base build (JDK8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
     - env: SONAR='true'
       jdk: oraclejdk8
     # OpenJDK - Java 11 (lts)
-    - env: SONAR='false' BUILD_OPTS='-Djava.version=11'
+    - env: SONAR='false' BUILD_OPTS='-Djava.version=11 -Dspring.version=5.1.10.RELEASE -Dspring.boot.version=2.1.9.RELEASE'
       jdk: openjdk11
     # OpenJDK - Java 12 (latest)
-    - env: SONAR='false' BUILD_OPTS='-Djava.version=12'
+    - env: SONAR='false' BUILD_OPTS='-Djava.version=12 -Dspring.version=5.1.10.RELEASE -Dspring.boot.version=2.1.9.RELEASE'
       jdk: openjdk12
 
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <citrus.version>2.8.0</citrus.version>
-    <spring.version>5.1.10.RELEASE</spring.version>
+    <spring.version>5.0.13.RELEASE</spring.version>
     <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
-    <spring.boot.version>2.1.9.RELEASE</spring.boot.version>
+    <spring.boot.version>2.0.9.RELEASE</spring.boot.version>
     <slf4j.version>1.7.28</slf4j.version>
 
     <logback.classic.version>1.2.3</logback.classic.version>


### PR DESCRIPTION
Because Spring Boot 2.0 does not support JDK11, we build the JDK11 and JDK12 builds against Spring Boot 2.1