### PR TITLE
fix(#46): Fixed ScenarioExecutionService to execute inherited run implementations

### DIFF
--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/AbstractGreetingScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/AbstractGreetingScenario.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.simulator.sample.scenario;
+
+import com.consol.citrus.simulator.scenario.AbstractSimulatorScenario;
+import com.consol.citrus.simulator.scenario.ScenarioRunner;
+import org.springframework.http.HttpStatus;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class AbstractGreetingScenario extends AbstractSimulatorScenario {
+
+    @Override
+    public void run(ScenarioRunner scenario) {
+        scenario.echo("Simulator: ${simulator.name}");
+
+        scenario
+            .http()
+            .receive(builder -> builder
+                    .post()
+                    .payload("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                            "Say Hello!" +
+                            "</Hello>")
+                    .extractFromPayload("//hello:Hello", "greeting")
+            );
+
+        scenario.echo("Received greeting: ${greeting}");
+
+        scenario
+            .http()
+            .send((builder -> builder
+                    .response(HttpStatus.OK)
+                    .payload(String.format("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">%s</HelloResponse>",
+                            getGreetingMessage())))
+            );
+    }
+
+    abstract String getGreetingMessage();
+}

--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/DefaultGreetingScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/DefaultGreetingScenario.java
@@ -1,0 +1,12 @@
+package com.consol.citrus.simulator.sample.scenario;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DefaultGreetingScenario extends AbstractGreetingScenario {
+
+    @Override
+    String getGreetingMessage() {
+        return "What's up!";
+    }
+}

--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/FriendlyHelloScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/FriendlyHelloScenario.java
@@ -1,0 +1,15 @@
+package com.consol.citrus.simulator.sample.scenario;
+
+import com.consol.citrus.simulator.scenario.Scenario;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Scenario("Hello")
+@RequestMapping(value = "/services/rest/simulator/hello", method = RequestMethod.POST)
+public class FriendlyHelloScenario extends HelloScenario{
+
+    @Override
+    String getMessage() {
+        return "there";
+    }
+}

--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HelloScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HelloScenario.java
@@ -26,9 +26,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 /**
  * @author Christoph Deppisch
  */
-@Scenario("Hello")
-@RequestMapping(value = "/services/rest/simulator/hello", method = RequestMethod.POST)
-public class HelloScenario extends AbstractSimulatorScenario {
+public abstract class HelloScenario extends AbstractSimulatorScenario {
 
     @Override
     public void run(ScenarioRunner scenario) {
@@ -51,8 +49,10 @@ public class HelloScenario extends AbstractSimulatorScenario {
             .send((builder -> builder
                     .response(HttpStatus.OK)
                     .payload("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Hi there!" +
+                            "Hi "+getMessage()+"!"+
                             "</HelloResponse>"))
             );
     }
+
+    abstract String getMessage();
 }

--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HelloScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HelloScenario.java
@@ -1,58 +1,15 @@
-/*
- * Copyright 2006-2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.consol.citrus.simulator.sample.scenario;
 
-import com.consol.citrus.simulator.scenario.AbstractSimulatorScenario;
 import com.consol.citrus.simulator.scenario.Scenario;
-import com.consol.citrus.simulator.scenario.ScenarioRunner;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-/**
- * @author Christoph Deppisch
- */
-public abstract class HelloScenario extends AbstractSimulatorScenario {
+@Scenario("Hello")
+@RequestMapping(value = "/services/rest/simulator/hello", method = RequestMethod.POST)
+public class HelloScenario extends AbstractGreetingScenario {
 
     @Override
-    public void run(ScenarioRunner scenario) {
-        scenario.echo("Simulator: ${simulator.name}");
-
-        scenario
-            .http()
-            .receive(builder -> builder
-                    .post()
-                    .payload("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Say Hello!" +
-                            "</Hello>")
-                    .extractFromPayload("//hello:Hello", "greeting")
-            );
-
-        scenario.echo("Received greeting: ${greeting}");
-
-        scenario
-            .http()
-            .send((builder -> builder
-                    .response(HttpStatus.OK)
-                    .payload("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Hi "+getMessage()+"!"+
-                            "</HelloResponse>"))
-            );
+    String getGreetingMessage() {
+        return "Hi there!";
     }
-
-    abstract String getMessage();
 }

--- a/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HowdyScenario.java
+++ b/simulator-samples/sample-rest/src/main/java/com/consol/citrus/simulator/sample/scenario/HowdyScenario.java
@@ -4,12 +4,12 @@ import com.consol.citrus.simulator.scenario.Scenario;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-@Scenario("Hello")
-@RequestMapping(value = "/services/rest/simulator/hello", method = RequestMethod.POST)
-public class FriendlyHelloScenario extends HelloScenario{
+@Scenario("Howdy")
+@RequestMapping(value = "/services/rest/simulator/howdy", method = RequestMethod.POST)
+public class HowdyScenario extends DefaultGreetingScenario {
 
     @Override
-    String getMessage() {
-        return "there";
+    String getGreetingMessage() {
+        return "Howdy partner!";
     }
 }

--- a/simulator-samples/sample-rest/src/test/java/com/consol/citrus/simulator/SimulatorRestIT.java
+++ b/simulator-samples/sample-rest/src/test/java/com/consol/citrus/simulator/SimulatorRestIT.java
@@ -69,6 +69,29 @@ public class SimulatorRestIT extends TestNGCitrusTestDesigner {
     }
 
     /**
+     * Sends a howdy request to server expecting positive response message.
+     */
+    @CitrusTest
+    public void testHowdyRequest() {
+        http().client(simulatorClient)
+                .send()
+                .post("howdy")
+                .contentType(MediaType.APPLICATION_XML_VALUE)
+                .payload("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                        "Say Hello!" +
+                        "</Hello>");
+
+        http().client(simulatorClient)
+                .receive()
+                .response(HttpStatus.OK)
+                .payload("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                        "Howdy partner!" +
+                        "</HelloResponse>");
+    }
+
+
+
+    /**
      * Sends goodbye request to server expecting positive response message.
      */
     @CitrusTest

--- a/simulator-starter/src/main/java/com/consol/citrus/simulator/service/ScenarioExecutionService.java
+++ b/simulator-starter/src/main/java/com/consol/citrus/simulator/service/ScenarioExecutionService.java
@@ -115,13 +115,9 @@ public class ScenarioExecutionService implements DisposableBean, ApplicationList
                     ((Executable) scenario).execute();
                 } else {
                     TestContext context = citrus.createTestContext();
-                    ReflectionUtils.doWithLocalMethods(scenario.getClass(), m -> {
+                    ReflectionUtils.doWithMethods(scenario.getClass(), m -> {
                         if (m.getDeclaringClass().equals(SimulatorScenario.class)) {
                             // no need to execute the default run implementations
-                            return;
-                        }
-
-                        if (!m.getName().equals("run")) {
                             return;
                         }
 
@@ -161,7 +157,7 @@ public class ScenarioExecutionService implements DisposableBean, ApplicationList
                         } else {
                             throw new SimulatorException("Invalid scenario method parameter type: " + parameterType);
                         }
-                    });
+                    }, method -> method.getName().equals("run"));
                 }
                 LOG.debug(String.format("Scenario completed: '%s'", name));
             } catch (Exception e) {


### PR DESCRIPTION
This PR includes the pure fix for #46 

The WIP code cleanup that required more regression testing has been moved to a separate branch that can be merged later on (https://github.com/citrusframework/citrus-simulator/tree/chore/46/code-cleanup).