### PR TITLE
Fix reserved keywords in models

### DIFF
--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
@@ -39,7 +39,7 @@ public class MessageHeader implements Serializable {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "`value`")
     private String value;
 
     @JsonIgnore

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
@@ -48,7 +48,7 @@ public class ScenarioParameter implements Serializable {
     @Column(nullable = false)
     private ControlType controlType;
 
-    @Column(columnDefinition = "CLOB")
+    @Column(columnDefinition = "CLOB", name = "`value`")
     @Lob
     private String value;
     private boolean required;


### PR DESCRIPTION
When building my own app based on the REST archetype, I noticed a bunch of hibernate related errors running schema migrations which were caused by exceptions such as:
```
Caused by: org.h2.jdbc.JdbcSQLSyntaxErrorException: Syntax error in SQL statement "create table message_header (header_id bigint generated by default as identity, name varchar(255) not null, [*]value varchar(255) not null, message_message_id bigint, primary key (header_id))"; expected "identifier"; SQL statement:
create table message_header (header_id bigint generated by default as identity, name varchar(255) not null, value varchar(255) not null, message_message_id bigint, primary key (header_id))
```
What it comes down to is that there are several column names clashing with reserved keywords (notice the asterisk indicating the clashing column name`[*]value`). I'm not sure if perhaps I'm noticing it because of a newer version of a dependency or if it just wasn't noticed before, but this is a pretty simple fix that shouldn't negatively affect anyone.

I noticed some failing test cases, but they're failing in main as well.