### PR TITLE
feat(#166): auditted entities

### DIFF
--- a/simulator-starter/src/main/java/org/citrusframework/simulator/controller/ActivityController.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/controller/ActivityController.java
@@ -20,9 +20,15 @@ import org.citrusframework.simulator.model.ScenarioExecution;
 import org.citrusframework.simulator.model.ScenarioExecutionFilter;
 import org.citrusframework.simulator.service.ActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 
 @RestController
 @RequestMapping("api/activity")
@@ -33,8 +39,8 @@ public class ActivityController {
 
     @RequestMapping(method = RequestMethod.GET)
     public Collection<ScenarioExecution> getScenarioExecutions(
-            @RequestParam(value = "fromDate", required = false) Date fromDate,
-            @RequestParam(value = "toDate", required = false) Date toDate,
+            @RequestParam(value = "fromDate", required = false) Instant fromDate,
+            @RequestParam(value = "toDate", required = false) Instant toDate,
             @RequestParam(value = "page", required = false) Integer page,
             @RequestParam(value = "size", required = false) Integer size
     ) {

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/AbstractAuditingEntity.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/AbstractAuditingEntity.java
@@ -1,0 +1,57 @@
+package org.citrusframework.simulator.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * Base abstract class for entities which will hold definitions for created and last modified by attributes.
+ */
+@MappedSuperclass
+@EntityListeners({ AuditingEntityListener.class })
+@JsonIgnoreProperties(value = { "createdDate", "lastModifiedDate" }, allowGetters = true)
+public abstract class AbstractAuditingEntity<T, I> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @CreatedDate
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private Instant createdDate = Instant.now();
+
+    @LastModifiedDate
+    @Column(name = "last_modified_date")
+    private Instant lastModifiedDate = Instant.now();
+
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public T createdDate(Instant createdDate) {
+        setCreatedDate(createdDate);
+        return (T) this;
+    }
+
+    public Instant getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(Instant lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+    public T lastModifiedDate(Instant lastModifiedDate) {
+        setLastModifiedDate(lastModifiedDate);
+        return (T) this;
+    }
+}

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/Message.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/Message.java
@@ -16,20 +16,31 @@
 
 package org.citrusframework.simulator.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 
-import jakarta.persistence.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 
 /**
  * JPA entity for representing inbound and outbound messages
  */
 @Entity
-public class Message implements Serializable {
-    private static final long serialVersionUID = -4858126051234255084L;
+public class Message extends AbstractAuditingEntity<Message, Long> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 2L;
 
     public enum Direction {
         INBOUND,
@@ -38,30 +49,25 @@ public class Message implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "MESSAGE_ID")
     private Long messageId;
-
-    @JsonIgnore
-    @ManyToOne
-    private ScenarioExecution scenarioExecution;
 
     @Column(nullable = false)
     private Direction direction;
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date date;
-
-    @Column(columnDefinition = "CLOB")
     @Lob
+    @Column(columnDefinition = "CLOB")
     private String payload;
 
     @Column(unique = true)
     private String citrusMessageId;
 
-    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("name ASC")
+    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
     private Collection<MessageHeader> headers = new ArrayList<>();
+
+    @ManyToOne
+    @JsonIgnoreProperties(value = { "scenarioParameters", "scenarioActions", "scenarioMessages" }, allowSetters = true)
+    private ScenarioExecution scenarioExecution;
 
     public Long getMessageId() {
         return messageId;
@@ -73,32 +79,6 @@ public class Message implements Serializable {
 
     public ScenarioExecution getScenarioExecution() {
         return scenarioExecution;
-    }
-
-    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
-        this.scenarioExecution = scenarioExecution;
-    }
-
-    public Long getScenarioExecutionId() {
-        if (scenarioExecution != null) {
-            return scenarioExecution.getExecutionId();
-        }
-        return null;
-    }
-
-    public String getScenarioName() {
-        if (scenarioExecution != null) {
-            return scenarioExecution.getScenarioName();
-        }
-        return null;
-    }
-
-    public Date getDate() {
-        return date;
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
     }
 
     public Direction getDirection() {
@@ -139,18 +119,35 @@ public class Message implements Serializable {
         return headers;
     }
 
+    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
+        this.scenarioExecution = scenarioExecution;
+    }
+
+    public Long getScenarioExecutionId() {
+        if (scenarioExecution != null) {
+            return scenarioExecution.getExecutionId();
+        }
+        return null;
+    }
+
+    public String getScenarioName() {
+        if (scenarioExecution != null) {
+            return scenarioExecution.getScenarioName();
+        }
+        return null;
+    }
+
 
     @Override
     public String toString() {
         return "Message{" +
-                "date=" + date +
-                ", messageId=" + messageId +
-                ", direction=" + direction +
-                ", payload='" + payload + '\'' +
-                ", citrusMessageId=" + citrusMessageId +
-                ", scenarioExecutionId=" + getScenarioExecutionId() +
-                ", scenarioName=" + getScenarioName() +
-                ", headers=" + headers +
+                "messageId='" + getMessageId() + "'" +
+                ", createdDate='" + getCreatedDate() + "'" +
+                ", direction='" + getDirection() + "'" +
+                ", payload='" + getPayload() + "'" +
+                ", citrusMessageId='" + getCitrusMessageId() + "'" +
+                ", headers='" + getHeaders() + "'" +
+                ", scenarioExecution='" + getScenarioExecution() + "'" +
                 '}';
     }
 

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageFilter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageFilter.java
@@ -16,16 +16,17 @@
 
 package org.citrusframework.simulator.model;
 
-import java.util.Date;
 import lombok.Data;
+
+import java.time.Instant;
 
 /**
  * Filter for filtering {@link Message}s
  */
 @Data
 public class MessageFilter {
-    private Date fromDate;
-    private Date toDate;
+    private Instant fromDate;
+    private Instant toDate;
     private Integer pageNumber;
     private Integer pageSize;
     private Boolean directionInbound;
@@ -42,5 +43,4 @@ public class MessageFilter {
      * filter.
      */
     private String headerFilter;
-
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
@@ -15,9 +15,17 @@
  */
 package org.citrusframework.simulator.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 
-import jakarta.persistence.*;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -26,14 +34,13 @@ import java.io.Serializable;
  * @author Georgi Todorov
  */
 @Entity
-public class MessageHeader implements Serializable {
+public class MessageHeader extends AbstractAuditingEntity<MessageHeader, Long> implements Serializable {
 
-    private static final long serialVersionUID = 6645135139541485915L;
+    @Serial
+    private static final long serialVersionUID = 2L;
 
-    @JsonIgnore
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "HEADER_ID")
     private Long headerId;
 
     @Column(nullable = false)
@@ -42,8 +49,10 @@ public class MessageHeader implements Serializable {
     @Column(nullable = false, name = "`value`")
     private String value;
 
-    @JsonIgnore
-    @ManyToOne
+    @NotNull
+    @ManyToOne(optional = false)
+    @JoinColumn(nullable = false)
+    @JsonIgnoreProperties(value = { "headers", "scenarioExecution" }, allowSetters = true)
     private Message message;
 
     public MessageHeader() {
@@ -89,10 +98,11 @@ public class MessageHeader implements Serializable {
     @Override
     public String toString() {
         return "MessageHeader{" +
-                "headerId=" + headerId +
-                ", name='" + name + '\'' +
-                ", value='" + value + '\'' +
+                "headerId='" + getHeaderId() + "'" +
+                ", createdDate='" + getCreatedDate() + "'" +
+                ", name='" + getName() + "'" +
+                ", value='" + getValue() + "'" +
+                ", message='" + getMessage() + "'" +
                 '}';
     }
-
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioAction.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioAction.java
@@ -16,11 +16,17 @@
 
 package org.citrusframework.simulator.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
-import jakarta.persistence.*;
+import java.io.Serial;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * JPA entity for representing a scenario action
@@ -28,23 +34,23 @@ import java.util.Date;
 @Entity
 public class ScenarioAction implements Serializable {
 
+    @Serial
+    private static final long serialVersionUID = 2L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ACTION_ID")
     private Long actionId;
-
-    @JsonIgnore
-    @ManyToOne
-    private ScenarioExecution scenarioExecution;
 
     @Column(nullable = false)
     private String name;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date startDate;
+    private Instant startDate;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date endDate;
+    private Instant endDate;
+
+    @ManyToOne
+    @JsonIgnoreProperties(value = { "scenarioParameters", "scenarioActions", "scenarioMessages" }, allowSetters = true)
+    private ScenarioExecution scenarioExecution;
 
     public Long getActionId() {
         return actionId;
@@ -52,30 +58,6 @@ public class ScenarioAction implements Serializable {
 
     public void setActionId(Long actionId) {
         this.actionId = actionId;
-    }
-
-    public ScenarioExecution getScenarioExecution() {
-        return scenarioExecution;
-    }
-
-    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
-        this.scenarioExecution = scenarioExecution;
-    }
-
-    public Date getStartDate() {
-        return startDate;
-    }
-
-    public void setStartDate(Date startDate) {
-        this.startDate = startDate;
-    }
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-    public void setEndDate(Date endDate) {
-        this.endDate = endDate;
     }
 
     public String getName() {
@@ -86,13 +68,38 @@ public class ScenarioAction implements Serializable {
         this.name = name;
     }
 
+    public Instant getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Instant startDate) {
+        this.startDate = startDate;
+    }
+
+    public Instant getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(Instant endDate) {
+        this.endDate = endDate;
+    }
+
+    public ScenarioExecution getScenarioExecution() {
+        return scenarioExecution;
+    }
+
+    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
+        this.scenarioExecution = scenarioExecution;
+    }
+
     @Override
     public String toString() {
         return "ScenarioAction{" +
-                "actionId=" + actionId +
-                ", name='" + name + '\'' +
-                ", startDate=" + startDate +
-                ", endDate=" + endDate +
+                "actionId='" + getActionId() + "'" +
+                ", name='" + getName() + "'" +
+                ", startDate='" + getStartDate() + "'" +
+                ", endDate='" + getEndDate() + "'" +
+                ", scenarioExecution='" + getScenarioExecution() + "'" +
                 '}';
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
@@ -18,7 +18,10 @@ package org.citrusframework.simulator.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -26,21 +29,14 @@ import java.util.List;
  * JPA entity for representing a scenario parameter
  */
 @Entity
-public class ScenarioParameter implements Serializable {
-    public enum ControlType {
-        TEXTBOX,
-        TEXTAREA,
-        DROPDOWN
-    }
+public class ScenarioParameter extends AbstractAuditingEntity<ScenarioParameter, Long> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 2L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "PARAMETER_ID")
     private Long parameterId;
-
-    @JsonIgnore
-    @ManyToOne
-    private ScenarioExecution scenarioExecution;
 
     @Column(nullable = false)
     private String name;
@@ -48,10 +44,16 @@ public class ScenarioParameter implements Serializable {
     @Column(nullable = false)
     private ControlType controlType;
 
-    @Column(columnDefinition = "CLOB", name = "`value`")
     @Lob
+    @Column(columnDefinition = "CLOB", name = "`value`")
     private String value;
+
+    @ManyToOne
+    @JsonIgnoreProperties(value = { "scenarioParameters", "scenarioActions", "scenarioMessages" }, allowSetters = true)
+    private ScenarioExecution scenarioExecution;
+
     private boolean required;
+
     private String label;
 
     @Transient
@@ -63,14 +65,6 @@ public class ScenarioParameter implements Serializable {
 
     public void setParameterId(Long parameterId) {
         this.parameterId = parameterId;
-    }
-
-    public ScenarioExecution getScenarioExecution() {
-        return scenarioExecution;
-    }
-
-    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
-        this.scenarioExecution = scenarioExecution;
     }
 
     public String getLabel() {
@@ -113,6 +107,14 @@ public class ScenarioParameter implements Serializable {
         this.value = value;
     }
 
+    public ScenarioExecution getScenarioExecution() {
+        return scenarioExecution;
+    }
+
+    public void setScenarioExecution(ScenarioExecution scenarioExecution) {
+        this.scenarioExecution = scenarioExecution;
+    }
+
     public boolean isRequired() {
         return required;
     }
@@ -124,13 +126,21 @@ public class ScenarioParameter implements Serializable {
     @Override
     public String toString() {
         return "ScenarioParameter{" +
-                "controlType=" + controlType +
-                ", parameterId=" + parameterId +
-                ", name='" + name + '\'' +
-                ", value='" + value + '\'' +
-                ", required=" + required +
-                ", label='" + label + '\'' +
-                ", options=" + options +
+                ", parameterId='" + getParameterId() +
+                ", createdDate='" + getCreatedDate() +
+                ", name='" + getName() + '\'' +
+                ", controlType='" + getControlType() +
+                ", value='" + getValue() + '\'' +
+                ", options='" + getScenarioExecution() +
+                ", required='" + isRequired() +
+                ", label='" + getLabel() +
+                ", options='" + getOptions() +
                 '}';
+    }
+
+    public enum ControlType {
+        TEXTBOX,
+        TEXTAREA,
+        DROPDOWN
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepository.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepository.java
@@ -22,7 +22,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -34,5 +34,5 @@ public interface ScenarioExecutionRepository extends CrudRepository<ScenarioExec
 
     List<ScenarioExecution> findByStatusOrderByStartDateDesc(@Param("status") ScenarioExecution.Status status);
 
-    List<ScenarioExecution> findByStartDateBetweenOrderByStartDateDesc(@Param("fromDate") Date fromDate, @Param("toDate") Date toDate, Pageable pageable);
+    List<ScenarioExecution> findByStartDateBetweenOrderByStartDateDesc(@Param("fromDate") Instant fromDate, @Param("toDate") Instant toDate, Pageable pageable);
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepositoryImpl.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepositoryImpl.java
@@ -22,12 +22,11 @@ import org.springframework.util.StringUtils;
 public class ScenarioExecutionRepositoryImpl extends AbstractRepository implements ScenarioExecutionRepositoryCustom {
 
     @Autowired
-    private EntityManager em;
+    private EntityManager entityManager;
 
     @Override
     public List<ScenarioExecution> find(ScenarioExecutionFilter filter) {
-
-        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ScenarioExecution> criteriaQuery = criteriaBuilder.createQuery(ScenarioExecution.class);
 
         Root<ScenarioExecution> scenarioExecution = criteriaQuery.from(ScenarioExecution.class);
@@ -41,7 +40,7 @@ public class ScenarioExecutionRepositoryImpl extends AbstractRepository implemen
 
         criteriaQuery.orderBy(criteriaBuilder.desc(scenarioExecution.get("startDate")));
 
-        TypedQuery<ScenarioExecution> messageQuery = em.createQuery(criteriaQuery.distinct(true));
+        TypedQuery<ScenarioExecution> messageQuery = entityManager.createQuery(criteriaQuery.distinct(true));
         addPagingRestrictions(filter, messageQuery);
 
         return messageQuery.getResultList();
@@ -143,15 +142,13 @@ public class ScenarioExecutionRepositoryImpl extends AbstractRepository implemen
      * @param predicates
      */
     private void addDatePredicates(ScenarioExecutionFilter filter, CriteriaBuilder criteriaBuilder,
-            Root<ScenarioExecution> scenarioExecution, List<Predicate> predicates) {
+                                   Root<ScenarioExecution> scenarioExecution, List<Predicate> predicates) {
         if (filter.getFromDate() != null) {
-            predicates.add(
-                    criteriaBuilder.greaterThanOrEqualTo(scenarioExecution.get("startDate"), filter.getFromDate()));
+            predicates.add(criteriaBuilder.greaterThanOrEqualTo(scenarioExecution.get("startDate"), filter.getFromDate()));
         }
 
         if (filter.getToDate() != null) {
             predicates.add(criteriaBuilder.lessThanOrEqualTo(scenarioExecution.get("endDate"), filter.getToDate()));
         }
     }
-
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/MessageService.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/MessageService.java
@@ -16,8 +16,9 @@
 
 package org.citrusframework.simulator.service;
 
-import org.citrusframework.exceptions.CitrusRuntimeException;
+import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.simulator.model.Message;
 import org.citrusframework.simulator.model.MessageFilter;
 import org.citrusframework.simulator.model.MessageHeader;
@@ -25,10 +26,6 @@ import org.citrusframework.simulator.repository.MessageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,7 +49,6 @@ public class MessageService {
 
     public Message saveMessage(Message.Direction direction, String payload, String citrusMessageId, Map<String, Object> headers) {
         Message message = new Message();
-        message.setDate(now());
         message.setDirection(direction);
         message.setPayload(payload);
         message.setCitrusMessageId(citrusMessageId);
@@ -80,9 +76,4 @@ public class MessageService {
     public void clearMessages() {
         messageRepository.deleteAll();
     }
-
-    private Date now() {
-        return Date.from(LocalDateTime.now().atZone(ZoneOffset.UTC).toInstant());
-    }
-
 }

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/service/MessageRepositoryTest.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/service/MessageRepositoryTest.java
@@ -13,9 +13,13 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.Assert;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @DataJpaTest
 @ContextConfiguration(classes = { SimulatorAutoConfiguration.class })
@@ -134,9 +138,9 @@ class MessageRepositoryTest extends AbstractTestNGSpringContextTests{
 
     @Test
     void testFindByAllParams() {
-        Date startSavingDate = now();
+        Instant startSavingDate = now();
         String uid = createTestMessage();
-        Date endSavingDate = now();
+        Instant endSavingDate = now();
 
         // Filter by all valid
         MessageFilter filter = new MessageFilter();
@@ -172,8 +176,8 @@ class MessageRepositoryTest extends AbstractTestNGSpringContextTests{
         Assert.assertEquals(33, result.size());
     }
 
-    private Date now() {
-        return Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC));
+    private Instant now() {
+        return LocalDateTime.now().toInstant(ZoneOffset.UTC);
     }
 
     private String createTestMessage() {

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/service/MessageServiceTest.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/service/MessageServiceTest.java
@@ -28,9 +28,9 @@ import org.springframework.data.domain.Pageable;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -76,8 +76,8 @@ public class MessageServiceTest {
 
     @Test
     public void shouldGetMessagesUsingNoDefaults() throws Exception {
-        Date dateFrom = new Date();
-        Date dateTo = new Date();
+        Instant dateFrom = Instant.now();
+        Instant dateTo = Instant.now();
         int pageNumber = 10;
         int pageSize = 1000;
         String text = "abc";


### PR DESCRIPTION
all entities which do not have any timing informatin (e.g. `startDate` or `endDate`) did now receive `createdDate` as well as `lastModifiedDate` information.

closes #166.