### PR TITLE
persist test results

### DIFF
--- a/simulator-samples/sample-swagger/src/test/java/org/citrusframework/simulator/SimulatorSwaggerIT.java
+++ b/simulator-samples/sample-swagger/src/test/java/org/citrusframework/simulator/SimulatorSwaggerIT.java
@@ -79,30 +79,6 @@ public class SimulatorSwaggerIT extends TestNGCitrusSpringSupport {
     }
 
     @CitrusTest
-    public void testUiSummaryResults() {
-        $(http().client(simulatorUiClient)
-                .send()
-                .get("/api/summary/results")
-                .message()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
-
-        $(http().client(simulatorUiClient)
-                .receive()
-                .response(HttpStatus.OK)
-                .message()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body("{" +
-                            "\"size\":\"@isNumber()@\"," +
-                            "\"failed\":\"@isNumber()@\"," +
-                            "\"success\":\"@isNumber()@\"," +
-                            "\"skipped\":0," +
-                            "\"skippedPercentage\":\"0.0\"," +
-                            "\"failedPercentage\":\"@ignore@\"," +
-                            "\"successPercentage\":\"@ignore@\"}"));
-    }
-
-    @CitrusTest
     public void testAddPet() {
         variable("name", "hasso");
         variable("category", "dog");

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/controller/SummaryController.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/controller/SummaryController.java
@@ -18,8 +18,11 @@ package org.citrusframework.simulator.controller;
 
 import org.citrusframework.report.TestResults;
 import org.citrusframework.simulator.listener.SimulatorStatusListener;
+import org.citrusframework.simulator.model.TestResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("api/summary")
@@ -34,8 +37,8 @@ public class SummaryController {
      * @return
      */
     @RequestMapping(method = RequestMethod.GET, value = "/results")
-    public TestResults getSummaryTestResults() {
-        return statusListener.getTestResults();
+    public List<TestResult> getSummaryTestResults() {
+        return statusListener.getTestResultService();
     }
 
     /**

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestParameter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestParameter.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Represents a parameter of a test result, holding a key-value pair of parameter details. It is linked to
+ * a {@link org.citrusframework.simulator.model.TestResult} entity through a many-to-one relationship, where
+ * a test result can have many parameters.
+ * <p>
+ * The entity includes a composite primary key represented by {@link TestParameterId}, which includes the
+ * parameter key and the ID of the associated test result. This composite key ensures that parameter entries
+ * are unique based on both the key and the test result ID.
+ * <p>
+ * This entity is not updatable, and it is recommended to add {@code @Column(updatable = false)} annotation
+ * to all applicable fields to enforce this constraint at the database level.
+ * <p>
+ * <b>Note:</b> This class contains a default constructor to satisfy Hibernate's requirement for a no-args constructor,
+ * as well as constructors for creating new instances based on specified values or existing non-persistent objects.
+ *
+ * @see org.citrusframework.simulator.model.TestResult
+ * @see org.citrusframework.simulator.model.AbstractAuditingEntity
+ */
+@Entity
+@Table(name = "test_parameter")
+public class TestParameter extends AbstractAuditingEntity<TestParameter, TestParameter.TestParameterId> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @EmbeddedId
+    private TestParameterId testParameterId;
+
+    @NotEmpty
+    @Column(name = "parameter_value", nullable = false, updatable = false)
+    private String value;
+
+    @ManyToOne
+    @MapsId("testResultId")
+    @JoinColumn(name = "test_result_id")
+    private TestResult testResult;
+
+    /**
+     * This is an empty constructor, not intended for "manual" usage.
+     * The Hibernate framework requires this in order to de- and serialize entities.
+     */
+    public TestParameter() {
+        // Hibernate constructor
+    }
+
+    /**
+     * Create a parameter entity from existing {@link org.citrusframework.TestResult} parameters.
+     *
+     * @param key   the parameter key
+     * @param value the parameter value
+     */
+    public TestParameter(String key, String value, TestResult testResult) {
+        this.testParameterId = new TestParameterId(key, testResult);
+        this.value = value;
+        this.testResult = testResult;
+    }
+
+    public String getKey() {
+        return testParameterId.key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public TestResult getTestResult() {
+        return testResult;
+    }
+
+    /**
+     * Represents a composite key for the {@link TestParameter} entity, encapsulating a parameter key
+     * and the ID of the associated {@link TestResult}. This ensures that the parameter entries are
+     * uniquely identified by both the key and the test result ID.
+     * <p>
+     * <b>Note:</b> This class contains a default constructor to satisfy Hibernate's requirements for a
+     * no-args constructor for composite keys. It also provides a constructor to facilitate the creation
+     * of a new composite key based on specified values.
+     * <p>
+     * This embedded ID class is not intended to be used directly in application code and exists mainly
+     * to satisfy JPA and database requirements.
+     *
+     * @see org.citrusframework.simulator.model.TestParameter
+     * @see org.citrusframework.simulator.model.TestResult
+     */
+    @Embeddable
+    public class TestParameterId implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        @Column(name = "parameter_key", nullable = false, updatable = false)
+        public String key;
+
+        @Column(nullable = false, updatable = false)
+        public Long testResultId;
+
+        /**
+         * This is an empty constructor, not intended for "manual" usage.
+         * The Hibernate framework requires this in order to de- and serialize composite keys.
+         */
+        public TestParameterId() {
+            // Hibernate constructor
+        }
+
+        /**
+         * Create a parameter composite key from existing {@link org.citrusframework.TestResult} parameters.
+         *
+         * @param key        the parameter key
+         * @param testResult the test-result this parameter is linked too
+         */
+        public TestParameterId(String key, TestResult testResult) {
+            this.key = key;
+            this.testResultId = testResult.getId();
+        }
+    }
+}

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestResult.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestResult.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents the persistent data model for a test result in the system. This class holds all information
+ * about a specific test including its status, name, class name, parameters, and any error messages or failure details.
+ * <p>
+ * The entity is not designed to be updated after creation; all {@code @Column} annotations should be configured with
+ * {@code updatable = false} to enforce this at the database level.
+ * <p>
+ * <b>Note:</b> This class contains a default constructor to satisfy Hibernate's requirement for a no-args constructor.
+ * It also provides a constructor that accepts an {@link org.citrusframework.TestResult} object to facilitate
+ * the creation of a new entity based on a non-persistent instance.
+ *
+ * @see org.citrusframework.simulator.model.TestParameter
+ * @see org.citrusframework.simulator.model.AbstractAuditingEntity
+ */
+@Entity
+public class TestResult extends AbstractAuditingEntity<TestResult, Long> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long id;
+
+    /**
+     * Actual result as a numerical representation of {@link Status}
+     */
+    @Column(nullable = false, updatable = false)
+    private int status;
+
+    /**
+     * Name of the test
+     */
+    @NotEmpty
+    @Column(nullable = false, updatable = false)
+    private String testName;
+
+    /**
+     * Fully qualified class name of the test
+     */
+    @NotEmpty
+    @Column(nullable = false, updatable = false)
+    private String className;
+
+    /**
+     * Optional test parameters
+     */
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "testResult")
+    private final Set<TestParameter> testParameters = new HashSet<>();
+
+    /**
+     * Error message
+     */
+    @Column(updatable = false)
+    private String errorMessage;
+
+    /**
+     * Failure stack trace
+     */
+    @Column(updatable = false)
+    private String failureStack;
+
+    /**
+     * Failure type information
+     */
+    @Column(updatable = false)
+    private String failureType;
+
+    /**
+     * This is an empty constructor, not intended for "manual" usage.
+     * The Hibernate framework requires this in order to de- and serialize entities.
+     */
+    public TestResult() {
+        // Hibernate constructor
+    }
+
+    /**
+     * Create a persistent copy of an existing {@link org.citrusframework.TestResult}.
+     *
+     * @param testResult the original {@link org.citrusframework.TestResult}
+     */
+    public TestResult(org.citrusframework.TestResult testResult) {
+        status = convertToStatus(testResult.getResult());
+        testName = testResult.getTestName();
+        className = testResult.getClassName();
+        testResult.getParameters().forEach((key, value) -> testParameters.add(new TestParameter(key, value.toString(), this)));
+        // NOte that the cause will be dropped: testResult.getCause()
+        errorMessage = testResult.getErrorMessage();
+        failureStack = testResult.getFailureStack();
+        failureType = testResult.getFailureType();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Status getStatus() {
+        return Arrays.stream(Status.values())
+                .filter(result -> result.id == status)
+                .findFirst()
+                .orElse(Status.UNKNOWN);
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public Set<TestParameter> getTestParameters() {
+        return testParameters;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getFailureStack() {
+        return failureStack;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+
+    private int convertToStatus(String resultName) {
+        return Arrays.stream(Status.values())
+                .filter(result -> result.name().equals(resultName))
+                .findFirst()
+                .orElse(Status.UNKNOWN)
+                .id;
+    }
+
+    public enum Status {
+
+        UNKNOWN(0), SUCCESS(1), FAILURE(2), SKIP(3);
+
+        private final int id;
+
+        Status(int i) {
+            this.id = i;
+        }
+    }
+}

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.repository;
+
+import org.citrusframework.simulator.model.TestResult;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestResultRepository extends CrudRepository<TestResult, Long> {
+
+}

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
@@ -17,10 +17,10 @@
 package org.citrusframework.simulator.repository;
 
 import org.citrusframework.simulator.model.TestResult;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TestResultRepository extends CrudRepository<TestResult, Long> {
+public interface TestResultRepository extends JpaRepository<TestResult, Long> {
 
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/TestResultService.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/TestResultService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.service;
+
+import org.citrusframework.simulator.repository.TestResultRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestResultService {
+
+    private final TestResultRepository testResultRepository;
+
+    public TestResultService(TestResultRepository testResultRepository) {
+        this.testResultRepository = testResultRepository;
+    }
+}

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/TestResultService.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/TestResultService.java
@@ -16,8 +16,11 @@
 
 package org.citrusframework.simulator.service;
 
+import org.citrusframework.TestResult;
 import org.citrusframework.simulator.repository.TestResultRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class TestResultService {
@@ -26,5 +29,13 @@ public class TestResultService {
 
     public TestResultService(TestResultRepository testResultRepository) {
         this.testResultRepository = testResultRepository;
+    }
+
+    public org.citrusframework.simulator.model.TestResult save(TestResult result) {
+        return testResultRepository.save(new org.citrusframework.simulator.model.TestResult(result));
+    }
+
+    public List<org.citrusframework.simulator.model.TestResult> findAll() {
+        return testResultRepository.findAll();
     }
 }


### PR DESCRIPTION
as part I of #165 I've made sure that all test results will be persisted into the database. I've created another entity class, because the `org.citrusframework.report.TestResult` class is final. anyway, I think that's good practice to decouple the simulator from the core.

I've not put too much time into refactoring the REST API, I will do that in a follow up MR as part of #165 as well. I think the current REST API does not follow too much pattern and does bring little to no use (except the current UI, of course - but that's what I am gonna rework [or actually, already started reworking]).