### PR TITLE
feat(#167): add scenario executor thread config property

### DIFF
--- a/simulator-docs/src/main/asciidoc/concepts.adoc
+++ b/simulator-docs/src/main/asciidoc/concepts.adoc
@@ -89,6 +89,7 @@ citrus.simulator.defaultScenario:: Default scenario name.
 citrus.simulator.defaultTimeout:: Timeout when waiting for inbound messages.
 citrus.simulator.templateValidation:: Enable/disable schema validation.
 citrus.simulator.exceptionDelay:: Default delay in milliseconds to wait after uncategorized exceptions.
+citrus.simulator.executor.threads:: The number of threads available for parallel scenario execution.
 citrus.simulator.rest.urlMapping:: Handler adapter url mapping for inbound requests
 citrus.simulator.ws.servletMapping:: Message dispatcher servlet mapping for inbound SOAP requests
 citrus.simulator.jms.inboundDestination:: JMS destination name to consume inbound messages from
@@ -109,6 +110,7 @@ citrus.simulator.default.scenario:: Default scenario name.
 citrus.simulator.default.timeout:: Timeout when waiting for inbound messages.
 citrus.simulator.template.validation:: Enable/disable schema validation.
 citrus.simulator.exception.delay:: Default delay in milliseconds to wait after uncategorized exceptions.
+citrus.simulator.executor.threads:: The number of threads available for parallel scenario execution.
 citrus.simulator.rest.url.mapping:: Handler adapter url mapping for inbound requests
 citrus.simulator.ws.servlet.mapping:: Message dispatcher servlet mapping for inbound SOAP requests
 citrus.simulator.jms.inbound.destination:: JMS destination name to consume inbound messages from
@@ -133,6 +135,7 @@ CITRUS_SIMULATOR_DEFAULT_SCENARIO:: Default scenario name.
 CITRUS_SIMULATOR_DEFAULT_TIMEOUT:: Timeout when waiting for inbound messages.
 CITRUS_SIMULATOR_TEMPLATE_VALIDATION:: Enable/disable schema validation.
 CITRUS_SIMULATOR_EXCEPTION_DELAY:: Default delay in milliseconds to wait after uncategorized exceptions.
+CITRUS_SIMULATOR_EXECUTOR_THREADS:: The number of threads available for parallel scenario execution.
 CITRUS_SIMULATOR_REST_URL_MAPPING:: Handler adapter url mapping for inbound requests
 CITRUS_SIMULATOR_WS_SERVLET_MAPPING:: Message dispatcher servlet mapping for inbound SOAP requests
 CITRUS_SIMULATOR_JMS_INBOUND_DESTINATION:: JMS destination name to consume inbound messages from

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
@@ -46,6 +46,8 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
     private static final String SIMULATOR_TEMPLATE_VALIDATION_ENV = "CITRUS_SIMULATOR_TEMPLATE_VALIDATION";
     private static final String SIMULATOR_EXCEPTION_DELAY_PROPERTY = "citrus.simulator.exception.delay";
     private static final String SIMULATOR_EXCEPTION_DELAY_ENV = "CITRUS_SIMULATOR_EXCEPTION_DELAY";
+    private static final String SIMULATOR_EXECUTOR_THREADS_PROPERTY = "citrus.simulator.executor.threads";
+    private static final String SIMULATOR_EXECUTOR_THREADS_ENV = "CITRUS_SIMULATOR_EXECUTOR_THREADS";
     private static final String SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.inbound.xml.dictionary";
     private static final String SIMULATOR_INBOUND_XML_DICTIONARY_ENV = "CITRUS_SIMULATOR_INBOUND_XML_DICTIONARY";
     private static final String SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.outbound.xml.dictionary";
@@ -88,6 +90,12 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
     private Long exceptionDelay = 5000L;
 
     /**
+     * Defines how many scenarios the simulator can run in parallel.
+     * Defaults to 10.
+     */
+    private int executorThreads = 10;
+
+    /**
      * Optional inbound XML data dictionary mapping file which gets automatically loaded when default inbound data dictionaries are enabled. Used in generated scenarios in order to manipulate generated test data.
      */
     private String inboundXmlDictionary = "inbound-xml-dictionary.xml";
@@ -124,6 +132,7 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
         defaultTimeout = Long.valueOf(env.getProperty(SIMULATOR_TIMEOUT_PROPERTY, env.getProperty(SIMULATOR_TIMEOUT_ENV, String.valueOf(defaultTimeout))));
         templateValidation = Boolean.parseBoolean(env.getProperty(SIMULATOR_TEMPLATE_VALIDATION_PROPERTY, env.getProperty(SIMULATOR_TEMPLATE_VALIDATION_ENV, String.valueOf(templateValidation))));
         exceptionDelay = Long.valueOf(env.getProperty(SIMULATOR_EXCEPTION_DELAY_PROPERTY, env.getProperty(SIMULATOR_EXCEPTION_DELAY_ENV, String.valueOf(exceptionDelay))));
+        executorThreads = Integer.parseInt(env.getProperty(SIMULATOR_EXECUTOR_THREADS_PROPERTY, env.getProperty(SIMULATOR_EXECUTOR_THREADS_ENV, Integer.toString(executorThreads))));
         inboundXmlDictionary = env.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_ENV, inboundXmlDictionary));
         outboundXmlDictionary = env.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_ENV, outboundXmlDictionary));
         inboundJsonDictionary = env.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_ENV, inboundJsonDictionary));
@@ -242,6 +251,21 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
     }
 
     /**
+     * Gets the number of threads available to the scenario executor.
+     */
+    public int getExecutorThreads() {
+        return executorThreads;
+    }
+
+    /**
+     * Sets the number of threads for parallel scenario execution.
+     * @param executorThreads
+     */
+    public void setExecutorThreads(int executorThreads) {
+        this.executorThreads = executorThreads;
+    }
+
+    /**
      * Gets the inboundXmlDictionary.
      *
      * @return
@@ -339,6 +363,7 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
                 ", defaultScenario='" + defaultScenario + '\'' +
                 ", defaultTimeout=" + defaultTimeout +
                 ", exceptionDelay=" + exceptionDelay +
+                ", executorThreads=" + executorThreads +
                 ", templateValidation=" + templateValidation +
                 ", inboundXmlDictionary=" + inboundXmlDictionary +
                 ", outboundXmlDictionary=" + outboundXmlDictionary +

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.citrusframework.Citrus;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.exception.SimulatorException;
 import org.citrusframework.simulator.model.ScenarioExecution;
 import org.citrusframework.simulator.model.ScenarioParameter;
@@ -55,18 +56,22 @@ public class ScenarioExecutionService implements DisposableBean, ApplicationList
     private final ApplicationContext applicationContext;
     private final Citrus citrus;
 
-    private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("execution-svc-thread-%d")
-            .build();
-
-    private final ExecutorService executorService = Executors.newFixedThreadPool(10, threadFactory);
+    private final ExecutorService executorService;
 
     @Autowired
-    public ScenarioExecutionService(ActivityService activityService, ApplicationContext applicationContext, Citrus citrus) {
+    public ScenarioExecutionService(ActivityService activityService, ApplicationContext applicationContext,
+                                    Citrus citrus, SimulatorConfigurationProperties properties) {
         this.activityService = activityService;
         this.applicationContext = applicationContext;
         this.citrus = citrus;
+
+        this.executorService = Executors.newFixedThreadPool(
+            properties.getExecutorThreads(),
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("execution-svc-thread-%d")
+                .build()
+        );
     }
 
     /**


### PR DESCRIPTION
Adds a property to the scenario configuration, which was previously hardcoded to 10, and now allows specifying the number of threads for async scenario execution. Fixes #167.