### PR TITLE
fix(deps): transitive dependency vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <spring-boot.version>3.1.5</spring-boot.version>
     <spring.version>6.0.13</spring.version>
     <spring.ws.version>4.0.7</spring.ws.version>
-    <testng.version>7.5.1</testng.version>
+    <testng.version>7.8.0</testng.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <xerces.version>2.12.1</xerces.version>
 
@@ -220,7 +220,7 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser</artifactId>
-        <version>2.1.16</version>
+        <version>2.1.18</version>
       </dependency>
 
       <dependency>

--- a/simulator-starter/pom.xml
+++ b/simulator-starter/pom.xml
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>2.2.224</version>
     </dependency>
 
     <!-- jakarta API -->


### PR DESCRIPTION
* [CVE-2022-4065](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065) reported in `org.testng:testng:7.5.1`
* [CVE-2022-45868](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45868) reported in `com.h2database.h2:2.1.114`