### PR TITLE
fix: scenario cache idempotency

### DIFF
--- a/simulator-starter/src/main/java/org/citrusframework/simulator/http/HttpRequestAnnotationMatcher.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/http/HttpRequestAnnotationMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.http;
 
 import java.util.ArrayList;

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/ScenarioLookupService.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/ScenarioLookupService.java
@@ -32,7 +32,11 @@ public interface ScenarioLookupService {
 
     /**
      * Reloads the {@link SimulatorScenario} and {@link ScenarioStarter} from the current
-     * {@link ApplicationContext}
+     * {@link ApplicationContext}.
+     * <p>
+     * Note that this method is expected to publish a
+     * {@link org.citrusframework.simulator.events.ScenariosReloadedEvent} to the
+     * {@link ApplicationContext} after successful reload.
      */
     void evictAndReloadScenarioCache();
 

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/service/impl/ScenarioLookupServiceImpl.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/service/impl/ScenarioLookupServiceImpl.java
@@ -32,8 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -45,7 +43,6 @@ public class ScenarioLookupServiceImpl implements InitializingBean, ScenarioLook
     private static final Logger logger = LoggerFactory.getLogger(ScenarioLookupServiceImpl.class);
 
     private final ApplicationContext applicationContext;
-    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * List of available scenarios
@@ -58,9 +55,8 @@ public class ScenarioLookupServiceImpl implements InitializingBean, ScenarioLook
     private Map<String, ScenarioStarter> scenarioStarters;
 
 
-    public ScenarioLookupServiceImpl(ApplicationContext applicationContext, ApplicationEventPublisher applicationEventPublisher) {
+    public ScenarioLookupServiceImpl(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
-        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     private static Map<String, SimulatorScenario> getSimulatorScenarios(ApplicationContext context) {
@@ -88,14 +84,14 @@ public class ScenarioLookupServiceImpl implements InitializingBean, ScenarioLook
      * Reloads the {@link SimulatorScenario} and {@link ScenarioStarter} from the current {@link ApplicationContext}
      */
     @Override
-    public void evictAndReloadScenarioCache() {
+    public synchronized void evictAndReloadScenarioCache() {
         scenarios = getSimulatorScenarios(applicationContext);
         logger.debug("Scenarios found: {}", getScenarioNames());
 
         scenarioStarters = getScenarioStarters(applicationContext);
         logger.debug("Starters found: {}", getStarterNames());
 
-        applicationEventPublisher.publishEvent(new ScenariosReloadedEvent(this));
+        applicationContext.publishEvent(new ScenariosReloadedEvent(this));
     }
 
     /**

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/web/rest/ScenarioResource.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/web/rest/ScenarioResource.java
@@ -72,6 +72,8 @@ public class ScenarioResource {
         logger.debug("Scenarios found: {}", scenarioNames);
         logger.debug("Starters found: {}", scenarioStarterNames);
 
+        scenarioCache.clear();
+
         scenarioNames.forEach(name -> scenarioCache.add(new Scenario(name, Scenario.ScenarioType.MESSAGE_TRIGGERED)));
         scenarioStarterNames.forEach(name -> scenarioCache.add(new Scenario(name, Scenario.ScenarioType.STARTER)));
 

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/web/util/PaginationUtil.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/web/util/PaginationUtil.java
@@ -16,15 +16,13 @@
 
 package org.citrusframework.simulator.web.util;
 
-import java.util.Collection;
+import java.text.MessageFormat;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.text.MessageFormat;
 
 
 /**
@@ -39,6 +37,10 @@ public interface PaginationUtil {
      String HEADER_LINK_FORMAT = "<{0}>; rel=\"{1}\"";
 
      static <T> Page<T> createPage(List<T> objects, Pageable pageable) {
+         if (pageable.isUnpaged()) {
+             return new PageImpl<>(objects);
+         }
+
          int start = (int) pageable.getOffset();
          int end = Math.min((start + pageable.getPageSize()), objects.size());
 

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/events/ScenariosReloadedEventIT.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/events/ScenariosReloadedEventIT.java
@@ -1,0 +1,62 @@
+package org.citrusframework.simulator.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Objects;
+import org.apache.commons.lang3.NotImplementedException;
+import org.citrusframework.simulator.IntegrationTest;
+import org.citrusframework.simulator.scenario.ScenarioEndpoint;
+import org.citrusframework.simulator.scenario.SimulatorScenario;
+import org.citrusframework.simulator.service.ScenarioLookupService;
+import org.citrusframework.simulator.web.rest.ScenarioResource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.data.domain.Pageable;
+
+@IntegrationTest
+class ScenariosReloadedEventIT {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private ScenarioLookupService scenarioLookupService;
+
+    @Autowired
+    private ScenarioResource scenarioResource;
+
+    @Test
+    void publishEvent() {
+        int scenariosBeforeReload = countScenarioResourceScenarios();
+
+        SimulatorScenario simulatorScenario = new ScenariosReloadedEventITScenario();
+
+        ConfigurableListableBeanFactory beanFactory = ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
+        beanFactory.registerSingleton(simulatorScenario.getClass().getSimpleName(), simulatorScenario);
+
+        scenarioLookupService.evictAndReloadScenarioCache();
+
+        int scenariosAfterReload = countScenarioResourceScenarios();
+
+        assertEquals(scenariosBeforeReload + 1, scenariosAfterReload,
+            "evictAndReloadScenarioCache should detect and publish the new Scenario");
+    }
+
+    private int countScenarioResourceScenarios() {
+        return Objects.requireNonNull(
+                scenarioResource.getScenarios(Pageable.unpaged()).getBody()
+            )
+            .size();
+    }
+
+    private static final class ScenariosReloadedEventITScenario implements SimulatorScenario {
+
+        @Override
+        public ScenarioEndpoint getScenarioEndpoint() {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/web/rest/MessageHeaderResourceIT.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/web/rest/MessageHeaderResourceIT.java
@@ -7,8 +7,6 @@ import org.citrusframework.simulator.model.MessageHeader;
 import org.citrusframework.simulator.repository.MessageHeaderRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -32,7 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @IntegrationTest
 @AutoConfigureMockMvc
-@ExtendWith(MockitoExtension.class)
 public class MessageHeaderResourceIT {
 
     private static final String DEFAULT_NAME = "AAAAAAAAAA";

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/web/rest/ScenarioResourceTest.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/web/rest/ScenarioResourceTest.java
@@ -33,7 +33,7 @@ class ScenarioResourceTest {
     }
 
     @Test
-    void evictAndReloadScenarioCache() {
+    void evictAndReloadScenarioCacheIsIdempotent() {
         Set<String> mockScenarioNames = Set.of("Scenario2", "Scenario1");
         Set<String> mockStarterNames = Set.of("Starter2", "Starter1");
 
@@ -41,7 +41,14 @@ class ScenarioResourceTest {
         doReturn(mockStarterNames).when(scenarioLookupServiceMock).getStarterNames();
 
         fixture.evictAndReloadScenarioCache(new ScenariosReloadedEvent(scenarioLookupServiceMock));
+        verifyEvictAndReloadCache();
 
+        // Check that the cache is really evicted and reloaded, not appended
+        fixture.evictAndReloadScenarioCache(new ScenariosReloadedEvent(scenarioLookupServiceMock));
+        verifyEvictAndReloadCache();
+    }
+
+    private void verifyEvictAndReloadCache() {
         assertThat((List<Scenario>) ReflectionTestUtils.getField(fixture, "scenarioCache"))
             .hasSize(4)
             .extracting("name")

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/web/util/PaginationUtilTest.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/web/util/PaginationUtilTest.java
@@ -1,6 +1,7 @@
 package org.citrusframework.simulator.web.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -14,7 +15,7 @@ import org.springframework.data.domain.Pageable;
 class PaginationUtilTest {
 
     @Test
-    void testCreatePage() {
+    void createPage() {
         // Prepare test data
         List<String> allObjects = Arrays.asList("Object1", "Object2", "Object3", "Object4", "Object5");
         Pageable pageable = PageRequest.of(1, 2); // Requesting the second page with a size of 2
@@ -33,5 +34,20 @@ class PaginationUtilTest {
         assertEquals("Object4", page.getContent().get(1), "Second object on the second page");
         assertEquals(5, page.getTotalElements(), "Total elements should be 5");
         assertEquals(3, page.getTotalPages(), "Total pages should be 3");
+    }
+
+    @Test
+    void unpaged() {
+        // Prepare test data
+        List<String> allObjects = Arrays.asList("Object1", "Object2", "Object3", "Object4", "Object5");
+
+        // Call the method to test
+        Page<String> page = PaginationUtil.createPage(allObjects, Pageable.unpaged());
+
+        // Assertions
+        assertFalse(page.getPageable().isPaged(), "Result contains all objects, not a page");
+        assertEquals(allObjects, page.getContent(), "The page should contain all objects at once");
+        assertEquals(allObjects.size(), page.getTotalElements(), "Total elements should match available elements");
+        assertEquals(1, page.getTotalPages(), "Total pages should be 1");
     }
 }


### PR DESCRIPTION
scenario cache in scenario REST resource did add scenarios to existing, instead of evicting the cache beforehand. improved security by synchronising the source method.

additionally detected a bug in the `PaginationUtil` that occurred on unpaged requests.