### PR TITLE
Issues/issue175/allow multiple rest url mappings

### DIFF
--- a/simulator-starter/src/main/java/org/citrusframework/simulator/http/SimulatorRestConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/http/SimulatorRestConfigurationProperties.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.citrusframework.simulator.http;
 
 import jakarta.annotation.PostConstruct;
@@ -84,17 +99,17 @@ public class SimulatorRestConfigurationProperties implements EnvironmentAware {
     /**
      * Sets the urlMapping.
      *
-     * @param urlMapping
+     * @param urlMappings
      */
-    public void setUrlMappings(List<String> urlMapping) {
-        this.urlMappings = urlMapping != null? Collections.unmodifiableList(urlMapping) : Collections.emptyList();
+    public void setUrlMappings(List<String> urlMappings) {
+        this.urlMappings = urlMappings != null? Collections.unmodifiableList(urlMappings) : Collections.emptyList();
     }
 
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "{" +
                 "enabled='" + enabled + '\'' +
-                ", urlMappings='" + urlMappings + '\'' +
+                ", urlMappings='" + String.join(",",urlMappings) + '\'' +
                 '}';
     }
 

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/http/SimulatorRestConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/http/SimulatorRestConfigurationProperties.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.http;
 
 import jakarta.annotation.PostConstruct;
@@ -32,7 +33,7 @@ import org.springframework.core.env.Environment;
 public class SimulatorRestConfigurationProperties implements EnvironmentAware {
 
     /** Logger */
-    private static final Logger log = LoggerFactory.getLogger(SimulatorRestConfigurationProperties.class);
+    private static final Logger logger = LoggerFactory.getLogger(SimulatorRestConfigurationProperties.class);
 
     /**
      * System property constants and environment variable names. Post construct callback reads these values and overwrites
@@ -65,7 +66,7 @@ public class SimulatorRestConfigurationProperties implements EnvironmentAware {
             urlMappings = List.of(urlMapping.split(","));
         }
 
-        log.info("Using the simulator configuration: {}", this);
+        logger.info("Using the simulator configuration: {}", this);
     }
 
     /**
@@ -102,7 +103,7 @@ public class SimulatorRestConfigurationProperties implements EnvironmentAware {
      * @param urlMappings
      */
     public void setUrlMappings(List<String> urlMappings) {
-        this.urlMappings = urlMappings != null? Collections.unmodifiableList(urlMappings) : Collections.emptyList();
+        this.urlMappings = urlMappings != null ? Collections.unmodifiableList(urlMappings) : Collections.emptyList();
     }
 
     @Override

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/jms/SimulatorJmsConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/jms/SimulatorJmsConfigurationProperties.java
@@ -15,7 +15,7 @@ import jakarta.annotation.PostConstruct;
 public class SimulatorJmsConfigurationProperties implements EnvironmentAware {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(SimulatorJmsConfigurationProperties.class);
+    private static final Logger logger = LoggerFactory.getLogger(SimulatorJmsConfigurationProperties.class);
 
     /**
      * System property constants and environment variable names. Post construct callback reads these values and overwrites
@@ -75,7 +75,7 @@ public class SimulatorJmsConfigurationProperties implements EnvironmentAware {
         useSoap = Boolean.parseBoolean(env.getProperty(SIMULATOR_SOAP_ENVELOPE_PROPERTY, env.getProperty(SIMULATOR_SOAP_ENVELOPE_ENV, String.valueOf(useSoap))));
         pubSubDomain = Boolean.parseBoolean(env.getProperty(SIMULATOR_PUB_SUB_DOMAIN_PROPERTY, env.getProperty(SIMULATOR_PUB_SUB_DOMAIN_ENV, String.valueOf(pubSubDomain))));
 
-        log.info("Using the simulator configuration: {}", this.toString());
+        logger.info("Using the simulator configuration: {}", this.toString());
     }
 
     /**

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceClientConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceClientConfigurationProperties.java
@@ -32,7 +32,7 @@ public class SimulatorWebServiceClientConfigurationProperties implements Environ
     /**
      * Logger
      */
-    private static Logger log = LoggerFactory.getLogger(SimulatorWebServiceClientConfigurationProperties.class);
+    private static final Logger logger = LoggerFactory.getLogger(SimulatorWebServiceClientConfigurationProperties.class);
 
     /**
      * System property constants and environment variable names. Post construct callback reads these values and overwrites
@@ -62,7 +62,7 @@ public class SimulatorWebServiceClientConfigurationProperties implements Environ
                 env.getProperty(SIMULATOR_WSCLIENT_REQUEST_URL_ENV, requestUrl)
         );
 
-        log.info("Using the simulator configuration: {}", this.toString());
+        logger.info("Using the simulator configuration: {}", this.toString());
     }
 
     /**

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.simulator.ws;
 
 import org.slf4j.Logger;
@@ -15,7 +31,7 @@ import jakarta.annotation.PostConstruct;
 public class SimulatorWebServiceConfigurationProperties implements EnvironmentAware {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(SimulatorWebServiceConfigurationProperties.class);
+    private static final Logger logger = LoggerFactory.getLogger(SimulatorWebServiceConfigurationProperties.class);
 
     /**
      * System property constants and environment variable names. Post construct callback reads these values and overwrites
@@ -44,7 +60,7 @@ public class SimulatorWebServiceConfigurationProperties implements EnvironmentAw
     private void loadProperties() {
         servletMapping = env.getProperty(SIMULATOR_SERVLET_MAPPING_PROPERTY, env.getProperty(SIMULATOR_SERVLET_MAPPING_ENV, servletMapping));
 
-        log.info("Using the simulator configuration: {}", this.toString());
+        logger.info("Using the simulator configuration: {}", this.toString());
     }
 
     /**

--- a/simulator-starter/src/main/resources/META-INF/citrus-simulator.properties
+++ b/simulator-starter/src/main/resources/META-INF/citrus-simulator.properties
@@ -27,7 +27,7 @@ spring.resources.chain.enabled=true
 # Customize the static resource locations to include, in addition to the defaults, the simulator gui (located under /static/simulator-ui/)
 spring.web.resources.static-locations=classpath:/static/simulator-ui/, classpath:/META-INF/resources/, classpath:/resources/, classpath:/static/, classpath:/public/
 
-# actuator properties
+# Actuator properties
 management.endpoint.health.enabled=true
 management.endpoint.info.enabled=true
 management.endpoints.web.base-path=/api/manage
@@ -39,9 +39,8 @@ management.info.git.mode=full
 info.simulator.name=Citrus Simulator
 info.simulator.version=@project.version@
 
-# logging
+# Logging
 logging.level.org.citrusframework.simulator=INFO
 
-spring.h2.console.enabled=true
-spring.h2.console.path=/console/
+# Do not automatically create transaction contexts
 spring.jpa.open-in-view=false

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
@@ -1,16 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.citrusframework.simulator.ui.config;
 
 import jakarta.annotation.Nullable;
-import jakarta.servlet.http.HttpServlet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.citrusframework.simulator.http.SimulatorRestAdapter;
 import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
 import org.citrusframework.simulator.ui.filter.SpaWebFilter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,6 +35,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
@@ -31,31 +47,28 @@ public class SecurityConfiguration {
 
     private final @Nullable SimulatorRestConfigurationProperties simulatorRestConfigurationProperties;
     private final @Nullable SimulatorRestAdapter simulatorRestAdapter;
-    private final @Nullable ServletRegistrationBean<? extends HttpServlet> simulatorServletRegistrationBean;
+
+    private final @Nullable SimulatorWebServiceConfigurationProperties  simulatorWebServiceConfigurationProperties;
+    private final @Nullable SimulatorWebServiceAdapter simulatorWebServiceAdapter;
+
 
     public SecurityConfiguration(
         SimulatorUiConfigurationProperties simulatorUiConfigurationProperties,
         @Autowired(required = false) @Nullable SimulatorRestConfigurationProperties simulatorRestConfigurationProperties,
         @Autowired(required = false) @Nullable SimulatorRestAdapter simulatorRestAdapter,
-        @Autowired(required = false) @Nullable @Qualifier("simulatorServletRegistrationBean") ServletRegistrationBean<? extends HttpServlet> simulatorServletRegistrationBean) {
+        @Autowired(required = false) @Nullable SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationProperties,
+        @Autowired(required = false) @Nullable SimulatorWebServiceAdapter simulatorWebServiceAdapter
+        ) {
         this.simulatorUiConfigurationProperties = simulatorUiConfigurationProperties;
         this.simulatorRestConfigurationProperties = simulatorRestConfigurationProperties;
         this.simulatorRestAdapter = simulatorRestAdapter;
-        this.simulatorServletRegistrationBean = simulatorServletRegistrationBean;
-    }
-
-    private static void addPathWithinApplicationAwareServletMatchers(MvcRequestMatcher.Builder mvc, String urlMapping, List<RequestMatcher> requestMatchers) {
-        String pathWithinApplication = urlMapping.substring(ServletUtils.extractContextPath(urlMapping).length());
-        if (!pathWithinApplication.isEmpty()) {
-            requestMatchers.add(mvc.pattern(pathWithinApplication));
-        } else {
-            requestMatchers.add(mvc.pattern(urlMapping));
-        }
+        this.simulatorWebServiceConfigurationProperties = simulatorWebServiceConfigurationProperties;
+        this.simulatorWebServiceAdapter = simulatorWebServiceAdapter;
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
-        RequestMatcher simulationEndpointsRequestMatcher = getSimulationEndpointsRequestMatcher(mvc);
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        RequestMatcher simulationEndpointsRequestMatcher = getSimulationEndpointsRequestMatcher();
 
         http
             .cors(AbstractHttpConfigurer::disable)
@@ -87,25 +100,52 @@ public class SecurityConfiguration {
         return http.build();
     }
 
-    private RequestMatcher getSimulationEndpointsRequestMatcher(MvcRequestMatcher.Builder mvc) {
-        List<RequestMatcher> requestMatchers = new ArrayList<>();
+    private RequestMatcher getSimulationEndpointsRequestMatcher() {
+        List<String> urlMappings = new ArrayList<>();
+        configureRestMatchers(urlMappings);
+        configureWebServiceMatchers(urlMappings);
 
+        return new OrRequestMatcher(createMatchers(urlMappings));
+    }
+
+    private void configureWebServiceMatchers(List<String> urlMappings) {
+        if (!Objects.isNull(simulatorWebServiceConfigurationProperties)
+            && !Objects.isNull(simulatorWebServiceAdapter)
+            && simulatorWebServiceAdapter.servletMapping(
+            simulatorWebServiceConfigurationProperties) != null) {
+            urlMappings.add(simulatorWebServiceAdapter.servletMapping(
+                simulatorWebServiceConfigurationProperties));
+        } else if (!Objects.isNull(simulatorWebServiceConfigurationProperties)
+            && simulatorWebServiceConfigurationProperties.getServletMapping() != null) {
+            urlMappings.add(simulatorWebServiceConfigurationProperties.getServletMapping());
+        }
+    }
+
+    private void configureRestMatchers(List<String> urlMappings) {
         if (!Objects.isNull(simulatorRestConfigurationProperties) && !Objects.isNull(simulatorRestAdapter)) {
-            simulatorRestAdapter.urlMappings(simulatorRestConfigurationProperties)
-                .forEach(urlMapping -> requestMatchers.add(mvc.pattern(urlMapping)));
+            urlMappings.addAll(simulatorRestAdapter.urlMappings(
+                simulatorRestConfigurationProperties));
         } else if (!Objects.isNull(simulatorRestConfigurationProperties)) {
-            simulatorRestConfigurationProperties.getUrlMappings()
-                .forEach(urlMapping -> requestMatchers.add(mvc.pattern(urlMapping)));
+            urlMappings.addAll(simulatorRestConfigurationProperties.getUrlMappings());
         }
-        if (!Objects.isNull(simulatorServletRegistrationBean) && simulatorServletRegistrationBean.isEnabled()) {
-            simulatorServletRegistrationBean.getUrlMappings().forEach(urlMapping -> addPathWithinApplicationAwareServletMatchers(mvc, urlMapping, requestMatchers));
+    }
+
+    /**
+     * Create request matchers from url mappings.
+     * <p>
+     * Note that the configured urlMappings for simulator are always absolute. Therefore, we use an
+     * {@link AntPathRequestMatcher} for matching.
+     */
+    private static RequestMatcher[] createMatchers(List<String> urlMappings) {
+        List<RequestMatcher> matchers =  urlMappings.stream()
+            .map(AntPathRequestMatcher::new)
+            .collect(Collectors.toList());
+
+        if (matchers.isEmpty()) {
+            matchers.add(new AntPathRequestMatcher("/**/*"));
         }
 
-        if (requestMatchers.isEmpty()) {
-            requestMatchers.add(mvc.pattern("*"));
-        }
-
-        return new OrRequestMatcher(requestMatchers.toArray(new RequestMatcher[0]));
+        return matchers.toArray(new RequestMatcher[0]);
     }
 
     @Bean

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/filter/SpaWebFilter.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/filter/SpaWebFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.ui.filter;
 
 import jakarta.annotation.Nonnull;
@@ -20,15 +21,18 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
+
 public class SpaWebFilter extends OncePerRequestFilter {
 
+    private final String h2ConsolePath;
     private final RequestMatcher simulationEndpointsRequestMatcher;
 
-    public SpaWebFilter(RequestMatcher simulationEndpointsRequestMatcher) {
+    public SpaWebFilter(String h2ConsolePath, RequestMatcher simulationEndpointsRequestMatcher) {
+        this.h2ConsolePath = h2ConsolePath;
         this.simulationEndpointsRequestMatcher = simulationEndpointsRequestMatcher;
     }
 
@@ -39,7 +43,12 @@ public class SpaWebFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, @Nonnull HttpServletResponse response, @Nonnull FilterChain filterChain) throws ServletException, IOException {
         // Request URI includes the contextPath: if any, remove it.
         String path = request.getRequestURI().substring(request.getContextPath().length());
-        if (!path.startsWith("/api") && !path.startsWith("/v3/api-docs") && !path.contains(".") && !simulationEndpointsRequestMatcher.matches(request) && path.matches("/(.*)")) {
+        if (!path.startsWith("/api")
+            && !path.startsWith("/v3/api-docs")
+            && !path.startsWith(h2ConsolePath)
+            && !path.contains(".")
+            && !simulationEndpointsRequestMatcher.matches(request)
+            && path.matches("/(.*)")) {
             request.getRequestDispatcher("/index.html").forward(request, response);
             return;
         }

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/filter/SpaWebFilter.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/filter/SpaWebFilter.java
@@ -1,30 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.citrusframework.simulator.ui.filter;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 public class SpaWebFilter extends OncePerRequestFilter {
 
-    private final RequestMatcher simulatorRestRequestMatcher;
+    private final RequestMatcher simulationEndpointsRequestMatcher;
 
-    public SpaWebFilter(RequestMatcher simulatorRestRequestMatcher) {
-        this.simulatorRestRequestMatcher = simulatorRestRequestMatcher;
+    public SpaWebFilter(RequestMatcher simulationEndpointsRequestMatcher) {
+        this.simulationEndpointsRequestMatcher = simulationEndpointsRequestMatcher;
     }
 
     /**
      * Forwards any unmapped paths (except those containing a period) to the client {@code index.html}.
      */
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        // Request URI includes the contextPath: if any, removed it.
+    protected void doFilterInternal(HttpServletRequest request, @Nonnull HttpServletResponse response, @Nonnull FilterChain filterChain) throws ServletException, IOException {
+        // Request URI includes the contextPath: if any, remove it.
         String path = request.getRequestURI().substring(request.getContextPath().length());
-        if (!path.startsWith("/api") && !path.startsWith("/v3/api-docs") && !path.contains(".") && !simulatorRestRequestMatcher.matches(request) && path.matches("/(.*)")) {
+        if (!path.startsWith("/api") && !path.startsWith("/v3/api-docs") && !path.contains(".") && !simulationEndpointsRequestMatcher.matches(request) && path.matches("/(.*)")) {
             request.getRequestDispatcher("/index.html").forward(request, response);
             return;
         }

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/AbstractSecurityConfigurationIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/AbstractSecurityConfigurationIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.simulator.ui.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.citrusframework.simulator.ui.filter.SpaWebFilter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.web.SecurityFilterChain;
+
+abstract class AbstractSecurityConfigurationIT {
+
+    @Autowired
+    SecurityFilterChain filterChain;
+
+    @ParameterizedTest
+    @MethodSource
+    void testRequest(String name, String requestUri, String servletPath, String pathInfo, boolean forward) throws ServletException, IOException {
+        SpaWebFilter spaWebFilter = (SpaWebFilter) filterChain.getFilters().stream().filter(oneFilter -> oneFilter instanceof SpaWebFilter).findFirst().orElseThrow();
+
+        RequestDispatcher requestDispatcherMock = mock(RequestDispatcher.class);
+        HttpServletRequest requestMock = mock(HttpServletRequest.class);
+        doReturn(requestDispatcherMock).when(requestMock).getRequestDispatcher(any());
+
+        doReturn("PUT").when(requestMock).getMethod();
+        doReturn(requestUri.replace("%context%", getContext())).when(requestMock).getRequestURI();
+        doReturn(servletPath.replace("%context%", getContext())).when(requestMock).getServletPath();
+        doReturn(pathInfo).when(requestMock).getPathInfo();
+        doReturn("").when(requestMock).getContextPath();
+        doReturn(Collections.enumeration(List.of())).when(requestMock).getAttributeNames();
+
+        HttpServletResponse responseMock = mock(HttpServletResponse.class);
+        FilterChain filterChainMock  = mock(FilterChain.class);
+
+        spaWebFilter.doFilter(requestMock, responseMock , filterChainMock);
+
+        if (forward) {
+            verify(requestDispatcherMock, times(1)).forward(any(), any());
+            verify(filterChainMock, times(0)).doFilter(any(), any());
+        } else {
+            verify(requestDispatcherMock, times(0)).forward(any(), any());
+            verify(filterChainMock).doFilter(any(), any());
+        }
+
+    }
+
+    protected abstract String getContext();
+
+    static Stream<Arguments> testRequest() {
+        return Stream.of(
+            Arguments.of("Rest servlet", "/%context%/rest/my-rest-service", "/%context%/rest/my-rest-service", null, false),
+            Arguments.of("Classic servlet", "/%context%/rest/my-rest-service", "/%context%", "/rest/my-rest-service", false),
+            Arguments.of("Rest servlet with forward", "/service/rest/my-rest-service", "/service/rest/my-rest-service", null, true),
+            Arguments.of("Classic servlet with forward", "/service/rest/my-rest-service", "/service", "/rest/my-rest-service", true));
+    }
+
+}

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/AbstractSecurityConfigurationIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/AbstractSecurityConfigurationIT.java
@@ -13,23 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citrusframework.simulator.ui.config;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+package org.citrusframework.simulator.ui.config;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
 import org.citrusframework.simulator.ui.filter.SpaWebFilter;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,10 +28,29 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 abstract class AbstractSecurityConfigurationIT {
 
     @Autowired
     SecurityFilterChain filterChain;
+
+    static Stream<Arguments> testRequest() {
+        return Stream.of(
+            Arguments.of("Rest servlet", "/%context%/rest/my-rest-service", "/%context%/rest/my-rest-service", null, false),
+            Arguments.of("Classic servlet", "/%context%/rest/my-rest-service", "/%context%", "/rest/my-rest-service", false),
+            Arguments.of("Rest servlet with forward", "/service/rest/my-rest-service", "/service/rest/my-rest-service", null, true),
+            Arguments.of("Classic servlet with forward", "/service/rest/my-rest-service", "/service", "/rest/my-rest-service", true));
+    }
 
     @ParameterizedTest
     @MethodSource
@@ -59,9 +69,9 @@ abstract class AbstractSecurityConfigurationIT {
         doReturn(Collections.enumeration(List.of())).when(requestMock).getAttributeNames();
 
         HttpServletResponse responseMock = mock(HttpServletResponse.class);
-        FilterChain filterChainMock  = mock(FilterChain.class);
+        FilterChain filterChainMock = mock(FilterChain.class);
 
-        spaWebFilter.doFilter(requestMock, responseMock , filterChainMock);
+        spaWebFilter.doFilter(requestMock, responseMock, filterChainMock);
 
         if (forward) {
             verify(requestDispatcherMock, times(1)).forward(any(), any());
@@ -70,17 +80,7 @@ abstract class AbstractSecurityConfigurationIT {
             verify(requestDispatcherMock, times(0)).forward(any(), any());
             verify(filterChainMock).doFilter(any(), any());
         }
-
     }
 
     protected abstract String getContext();
-
-    static Stream<Arguments> testRequest() {
-        return Stream.of(
-            Arguments.of("Rest servlet", "/%context%/rest/my-rest-service", "/%context%/rest/my-rest-service", null, false),
-            Arguments.of("Classic servlet", "/%context%/rest/my-rest-service", "/%context%", "/rest/my-rest-service", false),
-            Arguments.of("Rest servlet with forward", "/service/rest/my-rest-service", "/service/rest/my-rest-service", null, true),
-            Arguments.of("Classic servlet with forward", "/service/rest/my-rest-service", "/service", "/rest/my-rest-service", true));
-    }
-
 }

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.simulator.ui.config;
+
+import java.util.List;
+import org.citrusframework.simulator.http.SimulatorRestAdapter;
+import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
+import org.citrusframework.simulator.ui.IntegrationTest;
+import org.citrusframework.simulator.ui.config.SecurityConfigurationWithAdaptersIT.AdapterConfiguration;
+import org.citrusframework.simulator.ui.test.TestApplication;
+import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * @author Thorsten Schlathoelter
+ */
+@IntegrationTest
+@SpringBootTest(classes = {TestApplication.class, AdapterConfiguration.class}, properties = {
+    "with-adapters=true"})
+@DirtiesContext
+class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationIT {
+
+    @Override
+    protected String getContext() {
+        return "modified-simulator";
+    }
+
+    @Configuration
+    protected static class AdapterConfiguration {
+
+        @Bean
+        @ConditionalOnProperty(name = "with-adapters", havingValue = "true")
+        public SimulatorRestAdapter simulatorRestAdapter() {
+            return new SimulatorRestAdapter() {
+                @Override
+                public List<String> urlMappings(
+                    SimulatorRestConfigurationProperties simulatorRestConfiguration) {
+                    return List.of("/modified-simulator/rest/**");
+                }
+            };
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "with-adapters", havingValue = "true")
+        public SimulatorWebServiceAdapter simulatorWebServiceAdapter() {
+            return new SimulatorWebServiceAdapter() {
+                public String servletMapping(
+                    SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+                    return "/modified-simulator/ws/*";
+                }
+            };
+        }
+    }
+}

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.ui.config;
 
-import java.util.List;
 import org.citrusframework.simulator.http.SimulatorRestAdapter;
 import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
 import org.citrusframework.simulator.ui.IntegrationTest;
@@ -23,19 +23,22 @@ import org.citrusframework.simulator.ui.config.SecurityConfigurationWithAdapters
 import org.citrusframework.simulator.ui.test.TestApplication;
 import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
 import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
+import java.util.List;
+
 /**
  * @author Thorsten Schlathoelter
  */
-@IntegrationTest
-@SpringBootTest(classes = {TestApplication.class, AdapterConfiguration.class}, properties = {
-    "with-adapters=true"})
+@Isolated
 @DirtiesContext
+@IntegrationTest
+@SpringBootTest(classes = {TestApplication.class, AdapterConfiguration.class}, properties = {"with-adapters=true"})
 class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationIT {
 
     @Override
@@ -51,8 +54,7 @@ class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationI
         public SimulatorRestAdapter simulatorRestAdapter() {
             return new SimulatorRestAdapter() {
                 @Override
-                public List<String> urlMappings(
-                    SimulatorRestConfigurationProperties simulatorRestConfiguration) {
+                public List<String> urlMappings(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
                     return List.of("/modified-simulator/rest/**");
                 }
             };
@@ -62,8 +64,7 @@ class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationI
         @ConditionalOnProperty(name = "with-adapters", havingValue = "true")
         public SimulatorWebServiceAdapter simulatorWebServiceAdapter() {
             return new SimulatorWebServiceAdapter() {
-                public String servletMapping(
-                    SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+                public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
                     return "/modified-simulator/ws/*";
                 }
             };

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithoutAdaptersIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithoutAdaptersIT.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.simulator.ui.config;
+
+import org.citrusframework.simulator.ui.IntegrationTest;
+
+/**
+ * @author Thorsten Schlathoelter
+ */
+@IntegrationTest
+class SecurityConfigurationWithoutAdaptersIT extends AbstractSecurityConfigurationIT {
+
+    protected String getContext() {
+        return "simulator";
+    }
+
+}

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithoutAdaptersIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithoutAdaptersIT.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.simulator.ui.config;
 
 import org.citrusframework.simulator.ui.IntegrationTest;
@@ -26,5 +27,4 @@ class SecurityConfigurationWithoutAdaptersIT extends AbstractSecurityConfigurati
     protected String getContext() {
         return "simulator";
     }
-
 }

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterIT.java
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citrusframework.simulator.ui.filter;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+package org.citrusframework.simulator.ui.filter;
 
 import org.citrusframework.simulator.ui.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 @AutoConfigureMockMvc

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterIT.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.citrusframework.simulator.ui.filter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.citrusframework.simulator.ui.IntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -6,17 +26,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @IntegrationTest
 @AutoConfigureMockMvc
 class SpaWebFilterIT {
 
-    private static final String REST_URL_MAPPING = "/simulator/rest";
-    private static final String WS_SERVLET_PATH = "/simulator/ws";
+    private static final String REST_URL_MAPPING = "/simulator/rest/my-rest-service";
+    private static final String WS_SERVLET_PATH = "/simulator/ws/my-ws-service";
 
     @Autowired
     private MockMvc mockMvc;

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterTest.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/filter/SpaWebFilterTest.java
@@ -5,12 +5,12 @@ import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -26,7 +26,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SpaWebFilterTest {
 
-    @Mock(name = "simulatorRestRequestMatcher")
+    private static final String H2_CONSOLE_PATH = "/h2-console";
+
+    @Mock
     private RequestMatcher simulatorRestRequestMatcherMock;
 
     @Mock
@@ -41,13 +43,13 @@ class SpaWebFilterTest {
     @Mock
     private RequestDispatcher requestDispatcherMock;
 
-    @InjectMocks
     private SpaWebFilter fixture;
 
     public static Stream<Arguments> shouldNotForwardPathToIndexHtml() {
         return Stream.of(
             Arguments.of("/api", ""),
             Arguments.of("/api/somepath", ""),
+            Arguments.of(H2_CONSOLE_PATH, ""),
             Arguments.of("/v3/api-docs", ""),
             Arguments.of("/v3/api-docs/somepath", ""),
             Arguments.of("/some/absolute/path.", ""),
@@ -59,6 +61,11 @@ class SpaWebFilterTest {
             Arguments.of("/server-1/some/absolute/path.", "/server-1"),
             Arguments.of("/server-1path/without/leading/slash", "/server-1")
         );
+    }
+
+    @BeforeEach
+    void beforeEachSetup() {
+        fixture = new SpaWebFilter(H2_CONSOLE_PATH, simulatorRestRequestMatcherMock);
     }
 
     @MethodSource

--- a/simulator-ui/src/test/resources/application.properties
+++ b/simulator-ui/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 citrus.simulator.rest.enabled=true
-citrus.simulator.rest.url-mappings=/simulator/rest
+citrus.simulator.rest.url-mappings=/simulator/rest/**
 
 citrus.simulator.ws.enabled=true
-citrus.simulator.ws.servlet-mapping=/simulator/ws
+citrus.simulator.ws.servlet-mapping=/simulator/ws/**


### PR DESCRIPTION
Fixed filter issue in SpaWebFilter. Matching must always be performed to the absolute url.