### PR TITLE
feat: scenario completion tracking

### DIFF
--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/EndpointMessageHandler.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/EndpointMessageHandler.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.simulator.endpoint;
 
+import static org.citrusframework.simulator.scenario.TestCaseUtils.getContainedEntityManagerOrDefault;
+
+import jakarta.persistence.EntityManager;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.Message;
@@ -38,9 +41,11 @@ public class EndpointMessageHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(EndpointMessageHandler.class);
 
+    private final EntityManager defaultEntityManager;
     private final MessageService messageService;
 
-    public EndpointMessageHandler(MessageService messageService) {
+    public EndpointMessageHandler(EntityManager entityManager, MessageService messageService) {
+        this.defaultEntityManager = entityManager;
         this.messageService = messageService;
     }
 
@@ -62,7 +67,8 @@ public class EndpointMessageHandler {
                 direction,
                 message.getPayload(String.class),
                 citrusMessageId.get(),
-                message.getHeaders()
+                message.getHeaders(),
+                getContainedEntityManagerOrDefault(context.getVariables(), defaultEntityManager)
             );
         }
     }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapter.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
 
             try {
                 if (handleResponse) {
-                    return responseFuture.get(configuration.getDefaultTimeout(), TimeUnit.MILLISECONDS);
+                    return responseFuture.get(configuration.getDefaultScenarioTimeout(), TimeUnit.MILLISECONDS);
                 } else {
                     return null;
                 }
@@ -99,8 +99,7 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
             scenario = applicationContext.getBean(scenarioName, SimulatorScenario.class);
         } else {
             scenarioName = configuration.getDefaultScenario();
-            logger.info("Unable to find scenario for mapping '{}' - " +
-                    "using default scenario '{}'", mappingName, scenarioName);
+            logger.info("Unable to find scenario for mapping '{}' - using default scenario '{}'", mappingName, scenarioName);
             scenario = applicationContext.getBean(scenarioName, SimulatorScenario.class);
         }
 
@@ -110,7 +109,7 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
 
         try {
             if (handleResponse) {
-                return responseFuture.get(configuration.getDefaultTimeout(), TimeUnit.MILLISECONDS);
+                return responseFuture.get(configuration.getDefaultScenarioTimeout(), TimeUnit.MILLISECONDS);
             } else {
                 return null;
             }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
 
     @Override
     public void onTestStart(TestCase test) {
-        if (test instanceof DefaultTestCase) {
-            runningTests.put(StringUtils.arrayToCommaDelimitedString(getParameters(test)), TestResult.success(test.getName(), test.getTestClass().getSimpleName(), ((DefaultTestCase)test).getParameters()));
+        if (test instanceof DefaultTestCase defaultTestCase) {
+            runningTests.put(StringUtils.arrayToCommaDelimitedString(getParameters(test)), TestResult.success(test.getName(), test.getTestClass().getSimpleName(), defaultTestCase.getParameters()));
         } else {
             runningTests.put(StringUtils.arrayToCommaDelimitedString(getParameters(test)), TestResult.success(test.getName(), test.getTestClass().getSimpleName()));
         }
@@ -83,8 +83,8 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
     @Override
     public void onTestSuccess(TestCase test) {
         TestResult result;
-        if (test instanceof DefaultTestCase) {
-            result = TestResult.success(test.getName(), test.getTestClass().getSimpleName(), ((DefaultTestCase)test).getParameters());
+        if (test instanceof DefaultTestCase defaultTestCase) {
+            result = TestResult.success(test.getName(), test.getTestClass().getSimpleName(), defaultTestCase.getParameters());
         } else {
             result = TestResult.success(test.getName(), test.getTestClass().getSimpleName());
         }
@@ -98,8 +98,8 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
     @Override
     public void onTestFailure(TestCase test, Throwable cause) {
         TestResult result;
-        if (test instanceof DefaultTestCase) {
-            result = TestResult.failed(test.getName(), test.getTestClass().getSimpleName(), cause, ((DefaultTestCase)test).getParameters());
+        if (test instanceof DefaultTestCase defaultTestCase) {
+            result = TestResult.failed(test.getName(), test.getTestClass().getSimpleName(), cause, defaultTestCase.getParameters());
         } else {
             result = TestResult.failed(test.getName(), test.getTestClass().getSimpleName(), cause);
         }
@@ -140,8 +140,8 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
     private String[] getParameters(TestCase test) {
         List<String> parameterStrings = new ArrayList<>();
 
-        if (test instanceof DefaultTestCase) {
-            for (Map.Entry<String, Object> param : ((DefaultTestCase) test).getParameters().entrySet()) {
+        if (test instanceof DefaultTestCase defaultTestCase) {
+            for (Map.Entry<String, Object> param : defaultTestCase.getParameters().entrySet()) {
                 parameterStrings.add(param.getKey() + "=" + param.getValue());
             }
         }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/ScenarioRunner.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/ScenarioRunner.java
@@ -88,9 +88,9 @@ public class ScenarioRunner implements GherkinTestActionRunner {
 
     @Override
     public <T extends TestAction> T run(TestActionBuilder<T> builder) {
-        if (builder instanceof CorrelationHandlerBuilder) {
-            ((CorrelationHandlerBuilder) builder).setApplicationContext(applicationContext);
-            delegate.run(doFinally().actions(((CorrelationHandlerBuilder) builder).stop()));
+        if (builder instanceof CorrelationHandlerBuilder correlationHandlerBuilder) {
+            correlationHandlerBuilder.setApplicationContext(applicationContext);
+            delegate.run(doFinally().actions(correlationHandlerBuilder.stop()));
         }
 
         return delegate.run(builder);

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/TestCaseUtils.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/TestCaseUtils.java
@@ -1,0 +1,27 @@
+package org.citrusframework.simulator.scenario;
+
+import static org.citrusframework.simulator.service.impl.DefaultScenarioExecutorServiceImpl.ENTITY_MANAGER_VARIABLE_KEY;
+
+import jakarta.persistence.EntityManager;
+import java.util.Map;
+import org.citrusframework.TestCase;
+
+public final class TestCaseUtils {
+
+    private TestCaseUtils() {
+        // Not intended for instantiation
+    }
+
+    public static EntityManager getContainedEntityManagerOrDefault(TestCase testCase, EntityManager defaultEntityManager) {
+        return getContainedEntityManagerOrDefault(testCase.getVariableDefinitions(), defaultEntityManager);
+    }
+
+
+    public static EntityManager getContainedEntityManagerOrDefault(Map<String, Object> variableDefinitions, EntityManager defaultEntityManager) {
+        if (variableDefinitions.containsKey(ENTITY_MANAGER_VARIABLE_KEY) && variableDefinitions.get(ENTITY_MANAGER_VARIABLE_KEY) instanceof EntityManager containedEntityManager) {
+            return containedEntityManager;
+        }
+
+        return defaultEntityManager;
+    }
+}

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/MessageService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/MessageService.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.simulator.service;
 
+import jakarta.persistence.EntityManager;
 import org.citrusframework.simulator.model.Message;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -64,5 +65,5 @@ public interface MessageService {
      * @param headers             the message headers
      * @return the already or newly persisted message
      */
-    Message attachMessageToScenarioExecutionAndSave(Long scenarioExecutionId, Message.Direction direction, String payload, String citrusMessageId, Map<String, Object> headers);
+    Message attachMessageToScenarioExecutionAndSave(Long scenarioExecutionId, Message.Direction direction, String payload, String citrusMessageId, Map<String, Object> headers, EntityManager entityManager);
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
@@ -17,6 +17,7 @@
 package org.citrusframework.simulator.service;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.EntityManager;
 import org.citrusframework.TestCase;
 import org.citrusframework.simulator.model.ScenarioExecution;
 import org.citrusframework.simulator.model.ScenarioParameter;
@@ -68,9 +69,10 @@ public interface ScenarioExecutionService {
      *
      * @param scenarioName       the name of the scenario.
      * @param scenarioParameters the scenario's start parameters.
+     * @param entityManager      an entity manager with an open transaction used to persist the new {@link ScenarioExecution}.
      * @return the new entity.
      */
-    ScenarioExecution createAndSaveExecutionScenario(String scenarioName, @Nullable List<ScenarioParameter> scenarioParameters);
+    ScenarioExecution createAndSaveExecutionScenario(String scenarioName, @Nullable List<ScenarioParameter> scenarioParameters, EntityManager entityManager);
 
     /**
      * Mark a {@link ScenarioExecution} as completed successfully.

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/TestCaseUtil.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/TestCaseUtil.java
@@ -1,5 +1,7 @@
 package org.citrusframework.simulator.service.impl;
 
+import static org.citrusframework.simulator.model.ScenarioExecution.EXECUTION_ID;
+
 import org.citrusframework.TestCase;
 import org.citrusframework.simulator.model.ScenarioExecution;
 import org.slf4j.Logger;
@@ -14,7 +16,7 @@ class TestCaseUtil {
     }
 
     static long getScenarioExecutionId(TestCase testCase) {
-        logger.trace("Lookup '{}' in TestCaseParameters : {}", ScenarioExecution.EXECUTION_ID, testCase.getVariableDefinitions());
-        return Long.parseLong(testCase.getVariableDefinitions().get(ScenarioExecution.EXECUTION_ID).toString());
+        logger.trace("Lookup '{}' in TestCaseParameters : {}", EXECUTION_ID, testCase.getVariableDefinitions());
+        return Long.parseLong(testCase.getVariableDefinitions().get(EXECUTION_ID).toString());
     }
 }

--- a/simulator-spring-boot/src/main/resources/META-INF/citrus-simulator.properties
+++ b/simulator-spring-boot/src/main/resources/META-INF/citrus-simulator.properties
@@ -44,3 +44,4 @@ logging.level.org.citrusframework.simulator=INFO
 
 # Do not automatically create transaction contexts
 spring.jpa.open-in-view=false
+spring.jpa.show-sql=true

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/http/SimulatorRestAutoConfigurationTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/http/SimulatorRestAutoConfigurationTest.java
@@ -27,22 +27,22 @@ import static org.mockito.Mockito.doReturn;
 class SimulatorRestAutoConfigurationTest {
 
     @Mock
-    SimulatorRestConfigurationProperties simulatorRestConfigurationProperties;
+    private SimulatorRestConfigurationProperties simulatorRestConfigurationProperties;
 
     @Mock
-    SimulatorRestAdapter simulatorRestAdapter;
+    private SimulatorRestAdapter simulatorRestAdapter;
 
     @Mock
-    MessageListeners messageListeners;
+    private MessageListeners messageListeners;
 
     @Mock
-    SimulatorMessageListener simulatorMessageListener;
+    private SimulatorMessageListener simulatorMessageListener;
 
     @Mock
-    ApplicationContext applicationContext;
+    private ApplicationContext applicationContext;
 
     @InjectMocks
-    SimulatorRestAutoConfiguration simulatorRestAutoConfiguration;
+    private SimulatorRestAutoConfiguration simulatorRestAutoConfiguration;
 
     @Test
     void shouldHandleSingleUrlMappings() {

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/repository/MessageRepositoryIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/repository/MessageRepositoryIT.java
@@ -82,23 +82,7 @@ class MessageRepositoryIT {
     }
 
     private void verifyOnlyOneMessageFoundForScenarioExecution(Message expectedMessage) {
-        List<Message> allForScenarioExecution = messageRepository.findAllForScenarioExecution(scenarioExecution.getExecutionId(), expectedMessage.getCitrusMessageId(), expectedMessage.getDirection());
-        assertThat(allForScenarioExecution)
-            .hasSize(1)
-            .containsExactly(expectedMessage);
-    }
-
-    @Test
-    @Transactional
-    void findAllByScenarioExecutionExecutionIdEqualsAndCitrusMessageIdEqualsIgnoreCaseAndDirectionEquals() {
-        Message message2 = createAndPersistMessageForScenarioExecution(MessageResourceIT.createUpdatedEntity(entityManager), scenarioExecution);
-
-        verifyOnlyOneMessageFoundByIdentifier(message);
-        verifyOnlyOneMessageFoundByIdentifier(message2);
-    }
-
-    void verifyOnlyOneMessageFoundByIdentifier(Message expectedMessage) {
-        List<Message> allForScenarioExecution = messageRepository.findAllByScenarioExecutionExecutionIdEqualsAndCitrusMessageIdEqualsIgnoreCaseAndDirectionEquals(scenarioExecution.getExecutionId(), expectedMessage.getCitrusMessageId(), expectedMessage.getDirection().getId());
+        List<Message> allForScenarioExecution = messageRepository.findAllForScenarioExecution(scenarioExecution.getExecutionId(), expectedMessage.getDirection(), expectedMessage.getCitrusMessageId(), entityManager);
         assertThat(allForScenarioExecution)
             .hasSize(1)
             .containsExactly(expectedMessage);

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/scenario/TestCaseUtilsTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/scenario/TestCaseUtilsTest.java
@@ -1,0 +1,57 @@
+package org.citrusframework.simulator.scenario;
+
+import static org.citrusframework.simulator.service.impl.DefaultScenarioExecutorServiceImpl.ENTITY_MANAGER_VARIABLE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+import jakarta.persistence.EntityManager;
+import java.util.HashMap;
+import java.util.Map;
+import org.citrusframework.TestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({MockitoExtension.class})
+class TestCaseUtilsTest {
+
+    @Mock
+    private EntityManager defaultEntityManager;
+
+    @Mock
+    private EntityManager customEntityManager;
+
+    @Mock
+    private TestCase testCase;
+
+    @Test
+    void testGetContainedEntityManagerOrDefault_WithCustomEntityManager() {
+        Map<String, Object> variableDefinitions = new HashMap<>();
+        variableDefinitions.put(ENTITY_MANAGER_VARIABLE_KEY, customEntityManager);
+
+        doReturn(variableDefinitions).when(testCase).getVariableDefinitions();
+
+        EntityManager result = TestCaseUtils.getContainedEntityManagerOrDefault(testCase, defaultEntityManager);
+        assertEquals(customEntityManager, result, "Expected custom EntityManager to be returned");
+    }
+
+    @Test
+    void testGetContainedEntityManagerOrDefault_WithDefaultEntityManager() {
+        doReturn(new HashMap<>()).when(testCase).getVariableDefinitions();
+
+        EntityManager result = TestCaseUtils.getContainedEntityManagerOrDefault(testCase, defaultEntityManager);
+        assertEquals(defaultEntityManager, result, "Expected default EntityManager to be returned");
+    }
+
+    @Test
+    void testGetContainedEntityManagerOrDefault_WithInvalidType() {
+        Map<String, Object> variableDefinitions = new HashMap<>();
+        variableDefinitions.put(ENTITY_MANAGER_VARIABLE_KEY, new Object()); // Invalid type
+
+        doReturn(variableDefinitions).when(testCase).getVariableDefinitions();
+
+        EntityManager result = TestCaseUtils.getContainedEntityManagerOrDefault(testCase, defaultEntityManager);
+        assertEquals(defaultEntityManager, result, "Expected default EntityManager to be returned when invalid type is present");
+    }
+}

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/DefaultScenarioExecutorServiceImplIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/DefaultScenarioExecutorServiceImplIT.java
@@ -1,0 +1,75 @@
+package org.citrusframework.simulator.service.impl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PessimisticLockException;
+import jakarta.persistence.RollbackException;
+import org.citrusframework.simulator.IntegrationTest;
+import org.citrusframework.simulator.scenario.SimulatorScenario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@IntegrationTest
+@ExtendWith({MockitoExtension.class})
+@TestPropertySource({"classpath:META-INF/citrus-simulator.properties"})
+@TestPropertySource(properties = {"citrus.simulator.pessimistic-lock-timeout=0"})
+class DefaultScenarioExecutorServiceImplIT {
+
+    @Mock
+    private ExecutorService executorServiceMock;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private DefaultScenarioExecutorServiceImpl fixture;
+
+    @BeforeEach
+    void beforeEachSetup() {
+        setField(fixture, "executorService", executorServiceMock, ExecutorService.class);
+    }
+
+    @Test
+    void transactionBoundariesAndLockOnAsyncScenarioExecution() {
+        Long scenarioExecutionId = fixture.run(mock(SimulatorScenario.class), "ScenarioName", emptyList());
+        assertNotNull(scenarioExecutionId);
+
+        // At this point, the ScenarioExecution should be persisted, but locked!
+        try (EntityManager entityManager = entityManagerFactory.createEntityManager()) {
+            entityManager.getTransaction().begin();
+            // assertThrows(PessimisticLockException.class, () -> entityManager.createNativeQuery("SELECT count(execution_id) FROM scenario_execution WHERE execution_id=:" + ScenarioExecution_.EXECUTION_ID).setParameter(ScenarioExecution_.EXECUTION_ID, scenarioExecutionId).getFirstResult());
+            assertThrows(PessimisticLockException.class, () -> entityManager.createNativeQuery("DROP TABLE scenario_execution CASCADE").executeUpdate());
+            assertThrows(RollbackException.class, () -> entityManager.getTransaction().commit());
+        }
+
+        ArgumentCaptor<Runnable> scenarioRunnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorServiceMock).execute(scenarioRunnableArgumentCaptor.capture());
+
+        // This invokes the scenario execution with the captured runnable, the lock will be freed soon!
+        scenarioRunnableArgumentCaptor.getValue().run();
+
+        // Transaction has been committed, table no longer locked
+        try (EntityManager entityManager = entityManagerFactory.createEntityManager()) {
+            entityManager.getTransaction().begin();
+            // assertThrows(PessimisticLockException.class, () -> entityManager.createNativeQuery("SELECT count(execution_id) FROM scenario_execution WHERE execution_id=:" + ScenarioExecution_.EXECUTION_ID).setParameter(ScenarioExecution_.EXECUTION_ID, scenarioExecutionId).getFirstResult());
+            assertDoesNotThrow(() -> entityManager.createNativeQuery("DROP TABLE scenario_execution CASCADE").executeUpdate());
+            entityManager.getTransaction().commit();
+        }
+    }
+}

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/ScenarioExecutionServiceImplTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/ScenarioExecutionServiceImplTest.java
@@ -1,10 +1,12 @@
 package org.citrusframework.simulator.service.impl;
 
+import jakarta.persistence.EntityManager;
 import org.citrusframework.TestCase;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.simulator.model.ScenarioExecution;
 import org.citrusframework.simulator.model.ScenarioParameter;
 import org.citrusframework.simulator.repository.ScenarioExecutionRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.citrusframework.simulator.model.ScenarioExecution.EXECUTION_ID;
+import static org.citrusframework.simulator.service.impl.DefaultScenarioExecutorServiceImpl.ENTITY_MANAGER_VARIABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,7 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class ScenarioExecutionServiceImplTest {
@@ -38,7 +44,7 @@ class ScenarioExecutionServiceImplTest {
     private ScenarioExecutionRepository scenarioExecutionRepositoryMock;
 
     @Mock
-    TimeProvider timeProviderMock;
+    private TimeProvider timeProviderMock;
 
     private ScenarioExecution sampleScenarioExecution;
 
@@ -48,7 +54,7 @@ class ScenarioExecutionServiceImplTest {
     void beforeEachSetup() {
         sampleScenarioExecution = new ScenarioExecution();
 
-        fixture = new ScenarioExecutionServiceImpl(scenarioExecutionRepositoryMock);
+        fixture = new ScenarioExecutionServiceImpl(null, scenarioExecutionRepositoryMock);
         ReflectionTestUtils.setField(fixture, "timeProvider", timeProviderMock, TimeProvider.class);
     }
 
@@ -97,19 +103,27 @@ class ScenarioExecutionServiceImplTest {
     }
 
     @Test
-    void testCreateAndSaveExecutionScenario() {
+    void createAndSaveExecutionScenario() {
         String scenarioName = "sampleScenario";
 
         Instant now = Instant.now();
         doReturn(now).when(timeProviderMock).getTimeNow();
 
-        doAnswer(invocationOnMock -> invocationOnMock.getArgument(0, ScenarioExecution.class)).when(scenarioExecutionRepositoryMock).save(any(ScenarioExecution.class));
+        long executionId = 1234L;
+
+        EntityManager entityManagerMock = mock(EntityManager.class);
+        doAnswer(invocationOnMock -> {
+            ScenarioExecution scenarioExecution = invocationOnMock.getArgument(0, ScenarioExecution.class);
+            setField(scenarioExecution, "executionId", executionId, Long.class);
+            return null;
+        }).when(entityManagerMock).persist(any(ScenarioExecution.class));
 
         ScenarioParameter scenarioParameter = new ScenarioParameter();
         List<ScenarioParameter> scenarioParameters = List.of(scenarioParameter);
 
-        ScenarioExecution result = fixture.createAndSaveExecutionScenario(scenarioName, scenarioParameters);
+        ScenarioExecution result = fixture.createAndSaveExecutionScenario(scenarioName, scenarioParameters, entityManagerMock);
 
+        assertEquals(executionId, result.getExecutionId());
         assertEquals(scenarioName, result.getScenarioName());
         assertEquals(now, result.getStartDate());
         assertEquals(ScenarioExecution.Status.RUNNING, result.getStatus());
@@ -125,11 +139,19 @@ class ScenarioExecutionServiceImplTest {
         private final Instant now = Instant.now();
 
         @Mock
+        private EntityManager entityManagerMock;
+
+        @Mock
         private TestCase testCaseMock;
 
         @BeforeEach
         void beforeEachSetup() {
-            Map<String, String> variableDefinitions = Map.of(ScenarioExecution.EXECUTION_ID, String.valueOf(scenarioExecutionId));
+            setField(sampleScenarioExecution, "executionId", scenarioExecutionId);
+
+            Map<String, Object> variableDefinitions = Map.of(
+                ENTITY_MANAGER_VARIABLE_KEY, entityManagerMock,
+                EXECUTION_ID, String.valueOf(scenarioExecutionId)
+            );
             doReturn(variableDefinitions).when(testCaseMock).getVariableDefinitions();
         }
 
@@ -142,6 +164,8 @@ class ScenarioExecutionServiceImplTest {
             assertEquals(ScenarioExecution.Status.SUCCESS, result.getStatus());
             assertEquals(now, result.getEndDate());
             assertNull(result.getErrorMessage());
+
+            verifyNoInteractions(scenarioExecutionRepositoryMock);
         }
 
         @Test
@@ -149,10 +173,10 @@ class ScenarioExecutionServiceImplTest {
             String testName = "testCase";
             doReturn(testName).when(testCaseMock).getName();
 
-            doReturn(Optional.empty()).when(scenarioExecutionRepositoryMock).findOneByExecutionId(scenarioExecutionId);
+            doReturn(null).when(entityManagerMock).find(ScenarioExecution.class, scenarioExecutionId);
 
             CitrusRuntimeException exception = assertThrows(CitrusRuntimeException.class, () -> fixture.completeScenarioExecutionSuccess(testCaseMock));
-            assertEquals(String.format("Error while completing ScenarioExecution for test %s", testName), exception.getMessage());
+            assertEquals(String.format("Failed to find corresponding ScenarioExecution by executionId %s for test %s", scenarioExecutionId, testName), exception.getMessage());
         }
 
         @Test
@@ -166,7 +190,7 @@ class ScenarioExecutionServiceImplTest {
             assertEquals(now, result.getEndDate());
             assertTrue(result.getErrorMessage().startsWith("java.lang.RuntimeException: Failure cause"), "Error message must contain cause!");
 
-            verify(scenarioExecutionRepositoryMock).save(result);
+            verifyNoInteractions(scenarioExecutionRepositoryMock);
         }
 
         @Test
@@ -174,15 +198,21 @@ class ScenarioExecutionServiceImplTest {
             String testName = "testCase";
             doReturn(testName).when(testCaseMock).getName();
 
-            doReturn(Optional.empty()).when(scenarioExecutionRepositoryMock).findOneByExecutionId(scenarioExecutionId);
+            doReturn(null).when(entityManagerMock).find(ScenarioExecution.class, scenarioExecutionId);
 
             CitrusRuntimeException exception = assertThrows(CitrusRuntimeException.class, () -> fixture.completeScenarioExecutionFailure(testCaseMock, new RuntimeException("Failure cause")));
-            assertEquals(String.format("Error while completing ScenarioExecution for test %s", testName), exception.getMessage());
+            assertEquals(String.format("Failed to find corresponding ScenarioExecution by executionId %s for test %s", scenarioExecutionId, testName), exception.getMessage());
+
+            verifyNoInteractions(scenarioExecutionRepositoryMock);
+        }
+
+        @AfterEach
+        void afterEachTeardown() {
+            verifyNoInteractions(scenarioExecutionRepositoryMock);
         }
 
         private void preparePersistenceLayerMocks() {
-            doReturn(Optional.of(sampleScenarioExecution)).when(scenarioExecutionRepositoryMock).findOneByExecutionId(scenarioExecutionId);
-            doReturn(sampleScenarioExecution).when(scenarioExecutionRepositoryMock).save(sampleScenarioExecution);
+            doReturn(sampleScenarioExecution).when(entityManagerMock).find(ScenarioExecution.class, scenarioExecutionId);
             doReturn(now).when(timeProviderMock).getTimeNow();
         }
     }


### PR DESCRIPTION
Completion of scenario executions happens asynchronously, because scenarios with intermediate messaging must not block the main threads. Trying to achieve a sync outside the execution service is laborious at best. This implementation solves this problem, but **only for single-instance simulators**. E.g. not when running multiple pods in Kubernetes.

If you issue another request that requires the scenario to be completed, you still _may_ end up in states where the scenario hasn't been completed yet. That is, if you land on another instance of the simulator.