### PR TITLE
Draft: multiple ws endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,11 @@
 
     <javadoc.doclint>none</javadoc.doclint>
 
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
 
-    <lombok.version>1.18.20</lombok.version>
+    <lombok.version>1.18.30</lombok.version>
     <citrus.version>4.1.0</citrus.version>
+
     <spring-boot.version>3.2.1</spring-boot.version>
     <spring.version>6.1.3</spring.version>
     <testng.version>7.8.0</testng.version>

--- a/simulator-archetypes/archetype-jms/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-jms/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,18 +1,17 @@
 info.simulator.name=JMS Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable JMS support
 citrus.simulator.jms.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=10000
+citrus.simulator.default-timeout=10000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-archetypes/archetype-mail/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-mail/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,18 +1,17 @@
 info.simulator.name=Mail Server Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable Mail endpoint support
 citrus.simulator.endpoint.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-archetypes/archetype-rest/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-rest/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,18 +1,17 @@
 info.simulator.name=REST Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable Http REST support
 citrus.simulator.rest.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-archetypes/archetype-swagger/src/main/resources/archetype-resources/src/main/java/Simulator.java
+++ b/simulator-archetypes/archetype-swagger/src/main/resources/archetype-resources/src/main/java/Simulator.java
@@ -16,16 +16,22 @@
 
 package ${package};
 
+import java.util.List;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.StaticEndpointAdapter;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.simulator.scenario.mapper.ScenarioMapper;
 import org.citrusframework.simulator.scenario.mapper.ScenarioMappers;
+import org.citrusframework.simulator.http.HttpRequestAnnotationScenarioMapper;
+import org.citrusframework.simulator.http.HttpRequestPathScenarioMapper;
+import org.citrusframework.simulator.http.HttpScenarioGenerator;
+import org.citrusframework.simulator.http.SimulatorRestAdapter;
+import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
+import org.citrusframework.spi.Resources;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 
 @SpringBootApplication
@@ -42,8 +48,8 @@ public class Simulator extends SimulatorRestAdapter {
     }
 
     @Override
-    public String urlMapping(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
-        return "/petstore/v2/**";
+    public List<String> urlMappings(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
+        return List.of("/petstore/v2/**");
     }
 
     @Override

--- a/simulator-archetypes/archetype-swagger/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-swagger/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,24 +1,30 @@
 info.simulator.name=REST Petstore Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable Http REST support
 citrus.simulator.rest.enabled=true
 
 # Enable JSON data dictionary
 citrus.simulator.inbound.json.dictionary.enabled=true
-citrus.simulator.inboundJsonDictionary=classpath:dictionary/inbound-pet.properties
+citrus.simulator.inbound.json.dictionary.location=classpath:dictionary/inbound-pet.properties
 citrus.simulator.outbound.json.dictionary.enabled=true
-citrus.simulator.outboundJsonDictionary=classpath:dictionary/outbound-pet.properties
+citrus.simulator.outbound.json.dictionary.location=classpath:dictionary/outbound-pet.properties
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true
+
+# actuator properties
+management.endpoint.health.enabled=true
+management.endpoint.info.enabled=true
+management.endpoints.web.base-path=/api/manage
+management.endpoints.web.exposure.include=health,info
+management.info.env.enabled=true

--- a/simulator-archetypes/archetype-ws/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-ws/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,18 +1,17 @@
 info.simulator.name=SOAP Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable SOAP web service support
 citrus.simulator.ws.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-archetypes/archetype-wsdl/src/main/resources/archetype-resources/src/main/java/Simulator.java
+++ b/simulator-archetypes/archetype-wsdl/src/main/resources/archetype-resources/src/main/java/Simulator.java
@@ -16,14 +16,20 @@
 
 package ${package};
 
+import static java.util.Collections.singletonList;
+
+import java.util.List;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.StaticEndpointAdapter;
 import org.citrusframework.message.Message;
+import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
+import org.citrusframework.simulator.ws.WsdlScenarioGenerator;
+import org.citrusframework.spi.Resources;
 import org.citrusframework.ws.message.SoapFault;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.ClassPathResource;
 
 @SpringBootApplication
 public class Simulator extends SimulatorWebServiceAdapter {
@@ -33,8 +39,8 @@ public class Simulator extends SimulatorWebServiceAdapter {
     }
 
     @Override
-    public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
-        return "/services/ws/HelloService/v1/*";
+    public List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+        return singletonList("/services/ws/HelloService/*");
     }
 
     @Override

--- a/simulator-archetypes/archetype-wsdl/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/simulator-archetypes/archetype-wsdl/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,24 +1,23 @@
 info.simulator.name=SOAP WSDL Simulator
 logging.level.org.citrusframework=INFO
-logging.level.org.citrusframework=INFO
 
 # Enable SOAP web service support
 citrus.simulator.ws.enabled=true
 
 # Enable XML data dictionary
 citrus.simulator.inbound.xml.dictionary.enabled=true
-citrus.simulator.inboundXmlDictionary=classpath:dictionary/inbound_mappings.xml
+citrus.simulator.inbound.xml.dictionary.location=classpath:dictionary/inbound_mappings.xml
 citrus.simulator.outbound.xml.dictionary.enabled=true
-citrus.simulator.outboundXmlDictionary=classpath:dictionary/outbound_mappings.xml
+citrus.simulator.outbound.xml.dictionary.location=classpath:dictionary/outbound_mappings.xml
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
 citrus.simulator.defaultScenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-docs/src/main/asciidoc/concepts.adoc
+++ b/simulator-docs/src/main/asciidoc/concepts.adoc
@@ -65,8 +65,8 @@ Following from that, you can add properties to the `application.properties` file
 [source,properties]
 ----
 citrus.simulator.rest.enabled=true
-citrus.simulator.defaultTimeout=10000
-citrus.simulator.templatePath=com/company/simulator/templates
+citrus.simulator.default-timeout=10000
+citrus.simulator.template-path=com/company/simulator/templates
 ----
 
 The available simulator properties are grouped into the following configuration classes:
@@ -82,16 +82,16 @@ There are several properties that you can use to customize the simulator behavio
 
 .Spring Boot application properties
 [horizontal]
-`citrus.simulator.templatePath`:: Default path to message payload template files.
-`citrus.simulator.defaultScenario`:: Default scenario name.
-`citrus.simulator.defaultTimeout`:: Timeout when waiting for inbound messages.
-`citrus.simulator.templateValidation`:: Enable/disable schema validation.
-`citrus.simulator.exceptionDelay`:: Default delay in milliseconds to wait after uncategorized exceptions.
-`citrus.simulator.executor.threads`:: The number of threads available for parallel scenario execution.
-`citrus.simulator.rest.urlMapping`:: Handler adapter URL mapping for inbound requests.
-`citrus.simulator.ws.servletMappings`:: Message dispatcher servlet mappings for inbound SOAP requests.
-`citrus.simulator.jms.inboundDestination`:: JMS destination name to consume inbound messages from.
-`citrus.simulator.jms.replyDestination`:: JMS destination name to publish reply messages to.
+`citrus.simulator.template-path`:: Default path to message payload template files.
+`citrus.simulator.default-scenario`:: Default scenario name.
+`citrus.simulator.default-timeout`:: Timeout when waiting for inbound messages.
+`citrus.simulator.template-validation`:: Enable/disable schema validation.
+`citrus.simulator.exception-delay`:: Default delay in milliseconds to wait after uncategorized exceptions.
+`citrus.simulator.executor-threads`:: The number of threads available for parallel scenario execution.
+`citrus.simulator.rest.url-mapping`:: Handler adapter URL mapping for inbound requests.
+`citrus.simulator.ws.servlet-mappings`:: Message dispatcher servlet mappings for inbound SOAP requests.
+`citrus.simulator.jms.inbound-destination`:: JMS destination name to consume inbound messages from.
+`citrus.simulator.jms.reply-destination`:: JMS destination name to publish reply messages to.
 
 Please refer to the respective configuration property classes to see in detail what property settings are supported.
 
@@ -104,16 +104,16 @@ The properties include:
 .System property names
 [horizontal]
 `citrus.simulator.configuration.class`:: Java configuration class that is automatically loaded (default is org.citrusframework.simulator.SimulatorConfig).
-`citrus.simulator.template.path`:: Default path to message payload template files.
-`citrus.simulator.default.scenario`:: Default scenario name.
-`citrus.simulator.default.timeout`:: Timeout when waiting for inbound messages.
-`citrus.simulator.template.validation`:: Enable/disable schema validation.
-`citrus.simulator.exception.delay`:: Default delay in milliseconds to wait after uncategorized exceptions.
-`citrus.simulator.executor.threads`:: The number of threads available for parallel scenario execution.
-`citrus.simulator.rest.url.mapping`:: Handler adapter URL mapping for inbound requests.
-`citrus.simulator.ws.servlet.mapping`:: Message dispatcher servlet mapping for inbound SOAP requests.
-`citrus.simulator.jms.inbound.destination`:: JMS destination name to consume inbound messages from.
-`citrus.simulator.jms.reply.destination`:: JMS destination name to publish outbound messages to.
+`citrus.simulator.template-path`:: Default path to message payload template files.
+`citrus.simulator.default-scenario`:: Default scenario name.
+`citrus.simulator.default-timeout`:: Timeout when waiting for inbound messages.
+`citrus.simulator.template-validation`:: Enable/disable schema validation.
+`citrus.simulator.exception-delay`:: Default delay in milliseconds to wait after uncategorized exceptions.
+`citrus.simulator.executor-threads`:: The number of threads available for parallel scenario execution.
+`citrus.simulator.rest.url-mappings`:: Handler adapter URL mappings for inbound requests.
+`citrus.simulator.ws.servlet-mappings`:: Message dispatcher servlet mappings for inbound SOAP requests.
+`citrus.simulator.jms.inbound-destination`:: JMS destination name to consume inbound messages from.
+`citrus.simulator.jms.reply-destination`:: JMS destination name to publish outbound messages to.
 
 You can set these properties as system properties when starting the Spring Boot application, or you can add the properties to the default
 Spring Boot application properties file, `application.properties`, located as a resource file in your project.
@@ -135,8 +135,8 @@ This is extremely helpful when running the simulator in containerized infrastruc
 `CITRUS_SIMULATOR_TEMPLATE_VALIDATION`:: Enable/disable schema validation.
 `CITRUS_SIMULATOR_EXCEPTION_DELAY`:: Default delay in milliseconds to wait after uncategorized exceptions.
 `CITRUS_SIMULATOR_EXECUTOR_THREADS`:: The number of threads available for parallel scenario execution.
-`CITRUS_SIMULATOR_REST_URL_MAPPING`:: Handler adapter URL mapping for inbound requests.
-`CITRUS_SIMULATOR_WS_SERVLET_MAPPING`:: Message dispatcher servlet mapping for inbound SOAP requests.
+`CITRUS_SIMULATOR_REST_URL_MAPPINGS`:: Handler adapter URL mappings for inbound requests.
+`CITRUS_SIMULATOR_WS_SERVLET_MAPPINGS`:: Message dispatcher servlet mappings for inbound SOAP requests.
 `CITRUS_SIMULATOR_JMS_INBOUND_DESTINATION`:: JMS destination name to consume inbound messages from.
 `CITRUS_SIMULATOR_JMS_REPLY_DESTINATION`:: JMS destination name to publish outbound messages to.
 

--- a/simulator-docs/src/main/asciidoc/concepts.adoc
+++ b/simulator-docs/src/main/asciidoc/concepts.adoc
@@ -89,7 +89,7 @@ There are several properties that you can use to customize the simulator behavio
 `citrus.simulator.exceptionDelay`:: Default delay in milliseconds to wait after uncategorized exceptions.
 `citrus.simulator.executor.threads`:: The number of threads available for parallel scenario execution.
 `citrus.simulator.rest.urlMapping`:: Handler adapter URL mapping for inbound requests.
-`citrus.simulator.ws.servletMapping`:: Message dispatcher servlet mapping for inbound SOAP requests.
+`citrus.simulator.ws.servletMappings`:: Message dispatcher servlet mappings for inbound SOAP requests.
 `citrus.simulator.jms.inboundDestination`:: JMS destination name to consume inbound messages from.
 `citrus.simulator.jms.replyDestination`:: JMS destination name to publish reply messages to.
 

--- a/simulator-docs/src/main/asciidoc/rest-support.adoc
+++ b/simulator-docs/src/main/asciidoc/rest-support.adoc
@@ -40,8 +40,8 @@ public abstract class SimulatorRestAdapter implements SimulatorRestConfigurer {
     }
 
     @Override
-    public String urlMapping() {
-        return "/services/rest/**";
+    public List<String> urlMappings() {
+        return singletonList("/services/rest/**");
     }
 }
 ----
@@ -50,7 +50,7 @@ The adapter allows customization of REST handling, such as implementing differen
 
 *Note*: By default, the REST support uses the `HttpRequestAnnotationScenarioMapper` to search for `@RequestMapping` annotations on scenario classes.
 
-The `urlMapping` method defines the access path to the simulator's REST API.
+The `urlMappings` method defines the access path to the simulator's REST API.
 Assuming the Spring Boot application runs on port 8080, the API would be accessible at:
 
 [source]
@@ -68,8 +68,8 @@ Customize the simulator REST support by extending `SimulatorRestAdapter` in a cu
 public class MySimulatorRestAdapter extends SimulatorRestAdapter {
 
     @Override
-    public String urlMapping() {
-        return "/my-rest-service/**";
+    public List<String> urlMappings() {
+        return singletonList("/my-rest-service/**");
     }
 }
 ----
@@ -89,8 +89,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Simulator extends SimulatorRestAdapter {
 
     @Override
-    public String urlMapping() {
-        return "/my-rest-service/**";
+    public List<String> urlMappings() {
+        return singletonList("/my-rest-service/**");
     }
 
     @Override
@@ -255,8 +255,8 @@ public class Simulator extends SimulatorRestAdapter {
     }
 
     @Override
-    public String urlMapping(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
-        return "/petstore/v2/**";
+    public List<String> urlMappings(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
+        return singletonList("/petstore/v2/**");
     }
 
     @Override

--- a/simulator-docs/src/main/asciidoc/ws-support.adoc
+++ b/simulator-docs/src/main/asciidoc/ws-support.adoc
@@ -50,8 +50,8 @@ This adapter provides several configuration methods.
 public abstract class SimulatorWebServiceAdapter implements SimulatorWebServiceConfigurer {
 
     @Override
-    public String servletMapping() {
-        return "/services/ws/*";
+    public List<String> servletMappings() {
+        return singletonList("/services/ws/*");
     }
 
     @Override
@@ -67,7 +67,7 @@ public abstract class SimulatorWebServiceAdapter implements SimulatorWebServiceC
 ----
 
 This adapter defines methods to configure the simulator's SOAP message handling, such as adding different scenario mapper implementations or endpoint interceptors.
-The `servletMapping` method defines client access to the simulator's SOAP service.
+The `servletMappings` method defines client access to the simulator's SOAP service.
 For example, if the Spring Boot application runs on port 8080, the SOAP service would be accessible at:
 
 [source]
@@ -84,14 +84,14 @@ You can customize the simulator's SOAP support by extending `SimulatorWebService
 public class MySimulatorWebServiceAdapter extends SimulatorWebServiceAdapter {
 
     @Override
-    public String servletMapping() {
-        return "/my-soap-service/**";
+    public List<String> servletMappings() {
+        return singletonList("/my-soap-service/*");
     }
 }
 ----
 
 The class is annotated with `@Component` so that Spring recognizes it and overrides the default SOAP adapter behavior.
-By customizing the `servletMapping` method, the SOAP simulator API will be accessible under a new endpoint URI:
+By customizing the `servletMappings` method, the SOAP simulator API will be accessible under a new endpoint URI:
 
 [source]
 ----
@@ -110,8 +110,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Simulator extends SimulatorWebServiceAdapter {
 
     @Override
-    public String servletMapping() {
-        return "/my-soap-service/**";
+    public List<String> servletMappings() {
+        return singletonList("/my-soap-service/*");
     }
 
     @Override
@@ -248,8 +248,8 @@ public class Simulator extends SimulatorWebServiceAdapter {
     }
 
     @Override
-    public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
-        return "/services/ws/HelloService/v1/*";
+    public List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+        return singletonList("/services/ws/HelloService/v1/*");
     }
 
     @Override
@@ -344,9 +344,9 @@ You can define specific mappings in the dictionaries using XPath expressions:
 [source, properties]
 ----
 citrus.simulator.inbound.xml.dictionary.enabled=true
-citrus.simulator.inboundXmlDictionary=classpath:dictionary/inbound_mappings.xml
+citrus.simulator.inbound.xml.dictionary.location=classpath:dictionary/inbound_mappings.xml
 citrus.simulator.outbound.xml.dictionary.enabled=true
-citrus.simulator.outboundXmlDictionary=classpath:dictionary/outbound_mappings.xml
+citrus.simulator.outbound.xml.dictionary.location=classpath:dictionary/outbound_mappings.xml
 ----
 
 Inbound and outbound mapping files are specified for the dictionaries.

--- a/simulator-samples/sample-bank-service/src/main/java/org/citrusframework/simulator/sample/config/HttpClientConfig.java
+++ b/simulator-samples/sample-bank-service/src/main/java/org/citrusframework/simulator/sample/config/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,6 @@
 
 package org.citrusframework.simulator.sample.config;
 
-import java.io.IOException;
-import java.net.URL;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import javax.net.ssl.SSLContext;
-
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -34,17 +26,25 @@ import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.citrusframework.dsl.endpoint.CitrusEndpoints;
 import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
 @Configuration
 public class HttpClientConfig {
 
-    @Value("${citrus.simulator.defaultTimeout}")
-    private long defaultTimeout;
+    private final SimulatorConfigurationProperties simulatorConfigurationProperties;
 
     @Value("${server.port}")
     private int port;
@@ -55,11 +55,15 @@ public class HttpClientConfig {
     @Value("${server.ssl.key-store-password}")
     private String keyStorePassword;
 
+    public HttpClientConfig(SimulatorConfigurationProperties simulatorConfigurationProperties) {
+        this.simulatorConfigurationProperties = simulatorConfigurationProperties;
+    }
+
     @Bean
     public HttpClient simulatorHttpClientEndpoint() {
         return CitrusEndpoints.http()
                 .client()
-                .timeout(defaultTimeout)
+                .timeout(simulatorConfigurationProperties.getDefaultTimeout())
                 .requestUrl(String.format("https://localhost:%s/", port))
                 .requestFactory(sslRequestFactory())
                 .build();
@@ -92,5 +96,4 @@ public class HttpClientConfig {
     public HttpComponentsClientHttpRequestFactory sslRequestFactory() {
         return new HttpComponentsClientHttpRequestFactory(httpClient());
     }
-
 }

--- a/simulator-samples/sample-bank-service/src/main/resources/application.properties
+++ b/simulator-samples/sample-bank-service/src/main/resources/application.properties
@@ -14,10 +14,10 @@ server.ssl.key-store-type=JKS
 citrus.simulator.rest.enabled=true
 
 # Default timeout setting for HTTP requests and responses
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=false
+citrus.simulator.template-validation=false

--- a/simulator-samples/sample-bank-service/src/test/java/org/citrusframework/simulator/BankServiceSimulatorIT.java
+++ b/simulator-samples/sample-bank-service/src/test/java/org/citrusframework/simulator/BankServiceSimulatorIT.java
@@ -20,6 +20,7 @@ import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.container.BeforeSuite;
 import org.citrusframework.container.SequenceBeforeSuite;
 import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.sample.BankServiceSimulator;
 import org.citrusframework.simulator.sample.config.HttpClientConfig;
 import org.citrusframework.simulator.sample.model.BankAccount;
@@ -41,7 +42,7 @@ import org.testng.annotations.Test;
 import static org.citrusframework.http.actions.HttpActionBuilder.http;
 
 @Test
-@ContextConfiguration(classes = { BankServiceSimulatorIT.EndpointConfig.class, HttpClientConfig.class })
+@ContextConfiguration(classes = { BankServiceSimulatorIT.EndpointConfig.class, HttpClientConfig.class, SimulatorConfigurationProperties.class})
 public class BankServiceSimulatorIT extends TestNGCitrusSpringSupport {
 
     /**

--- a/simulator-samples/sample-combined/src/main/resources/application.properties
+++ b/simulator-samples/sample-combined/src/main/resources/application.properties
@@ -8,13 +8,13 @@ citrus.simulator.jms.enabled=true
 citrus.simulator.ws.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=org/citrusframework/simulator/templates
+citrus.simulator.template-path=org/citrusframework/simulator/templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-samples/sample-jms-fax/src/main/java/org/citrusframework/simulator/sample/jms/async/Simulator.java
+++ b/simulator-samples/sample-jms-fax/src/main/java/org/citrusframework/simulator/sample/jms/async/Simulator.java
@@ -47,7 +47,7 @@ public class Simulator extends SimulatorJmsAdapter {
     @Value("${spring.artemis.broker-url:tcp://localhost:61616}")
     private String brokerURL;
 
-    @Value("${citrus.simulator.jms.status.destination}")
+    @Value("${citrus.simulator.jms.status-destination}")
     private String statusDestinationName;
 
     @Override

--- a/simulator-samples/sample-jms-fax/src/main/resources/application.properties
+++ b/simulator-samples/sample-jms-fax/src/main/resources/application.properties
@@ -5,17 +5,17 @@ logging.level.org.citrusframework=INFO
 citrus.simulator.jms.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=org/citrusframework/citrus/simulator/templates
+citrus.simulator.template-path=org/citrusframework/citrus/simulator/templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=FaxQueued
+citrus.simulator.default-scenario=FaxQueued
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true
 
 # JMS destinations
-citrus.simulator.jms.inbound.destination=Fax.Inbound
-citrus.simulator.jms.status.destination=Fax.Status
+citrus.simulator.jms.inbound-destination=Fax.Inbound
+citrus.simulator.jms.status-destination=Fax.Status

--- a/simulator-samples/sample-jms/src/main/resources/application.properties
+++ b/simulator-samples/sample-jms/src/main/resources/application.properties
@@ -5,13 +5,13 @@ logging.level.org.citrusframework=INFO
 citrus.simulator.jms.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=10000
+citrus.simulator.default-timeout=10000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-samples/sample-mail/src/main/resources/application.properties
+++ b/simulator-samples/sample-mail/src/main/resources/application.properties
@@ -5,13 +5,13 @@ logging.level.org.citrusframework=INFO
 citrus.simulator.endpoint.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-samples/sample-rest/src/main/resources/application.properties
+++ b/simulator-samples/sample-rest/src/main/resources/application.properties
@@ -5,13 +5,13 @@ logging.level.org.citrusframework=INFO
 citrus.simulator.rest.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-samples/sample-swagger/src/main/resources/application.properties
+++ b/simulator-samples/sample-swagger/src/main/resources/application.properties
@@ -6,21 +6,21 @@ citrus.simulator.rest.enabled=true
 
 # Enable JSON data dictionary
 citrus.simulator.inbound.json.dictionary.enabled=true
-citrus.simulator.inboundJsonDictionary=classpath:dictionary/inbound-pet.properties
+citrus.simulator.inbound.json.dictionary.location=classpath:dictionary/inbound-pet.properties
 citrus.simulator.outbound.json.dictionary.enabled=true
-citrus.simulator.outboundJsonDictionary=classpath:dictionary/outbound-pet.properties
+citrus.simulator.outbound.json.dictionary.location=classpath:dictionary/outbound-pet.properties
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true
 
 # actuator properties
 management.endpoint.health.enabled=true

--- a/simulator-samples/sample-ws-client/src/main/resources/application.properties
+++ b/simulator-samples/sample-ws-client/src/main/resources/application.properties
@@ -5,16 +5,16 @@ logging.level.org.citrusframework=INFO
 citrus.simulator.ws.client.enabled=true
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=org/citrusframework/citrus/simulator/templates
+citrus.simulator.template-path=org/citrusframework/citrus/simulator/templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true
 
 # This is where the SOAP requests are sent to
-citrus.simulator.ws.client.requestUrl=http://localhost:8090/services/ws/simulator
+citrus.simulator.ws.client.request-url=http://localhost:8090/services/ws/simulator

--- a/simulator-samples/sample-ws-client/src/test/java/org/citrusframework/simulator/SimulatorWebServiceClientIT.java
+++ b/simulator-samples/sample-ws-client/src/test/java/org/citrusframework/simulator/SimulatorWebServiceClientIT.java
@@ -128,7 +128,8 @@ public class SimulatorWebServiceClientIT extends TestNGCitrusSpringSupport {
 
         @Bean
         public HttpClient simulatorRestEndpoint() {
-            return CitrusEndpoints.http().client()
+            return CitrusEndpoints.http()
+                    .client()
                     .requestUrl(String.format("http://localhost:%s", 8080))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .build();

--- a/simulator-samples/sample-ws/src/main/resources/application.properties
+++ b/simulator-samples/sample-ws/src/main/resources/application.properties
@@ -3,6 +3,7 @@ logging.level.org.citrusframework=INFO
 
 # Enable SOAP web service support
 citrus.simulator.ws.enabled=true
+citrus.simulator.ws.servlet-mappings=/services/ws/*,/services/ws/nested/*
 
 # Default timeout setting
 citrus.simulator.defaultTimeout=5000

--- a/simulator-samples/sample-ws/src/main/resources/application.properties
+++ b/simulator-samples/sample-ws/src/main/resources/application.properties
@@ -6,13 +6,13 @@ citrus.simulator.ws.enabled=true
 citrus.simulator.ws.servlet-mappings=/services/ws/*,/services/ws/nested/*
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
-citrus.simulator.defaultScenario=Default
+citrus.simulator.default-scenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/EndpointConfig.java
+++ b/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/EndpointConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator;
+
+import org.citrusframework.container.BeforeSuite;
+import org.citrusframework.container.SequenceBeforeSuite;
+import org.citrusframework.dsl.endpoint.CitrusEndpoints;
+import org.citrusframework.message.ErrorHandlingStrategy;
+import org.citrusframework.simulator.sample.Simulator;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.interceptor.LoggingClientInterceptor;
+import org.citrusframework.xml.XsdSchemaRepository;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+
+@Configuration
+public class EndpointConfig {
+    @Bean
+    public XsdSchemaRepository schemaRepository() {
+        XsdSchemaRepository schemaRepository = new XsdSchemaRepository();
+        schemaRepository.getLocations().add("classpath:xsd/HelloService.xsd");
+        return schemaRepository;
+    }
+
+    @Bean
+    public WebServiceClient simulatorClient() {
+        return CitrusEndpoints.soap().client()
+            .defaultUri(String.format("http://localhost:%s/services/ws/simulator", 8080))
+            .interceptor(loggingClientInterceptor())
+            .messageFactory(messageFactory())
+            .faultStrategy(ErrorHandlingStrategy.PROPAGATE)
+            .build();
+    }
+
+    @Bean
+    public WebServiceClient nestedSimulatorClient() {
+        return CitrusEndpoints.soap().client()
+            .defaultUri(String.format("http://localhost:%s/services/ws/nested/simulator", 8080))
+            .interceptor(loggingClientInterceptor())
+            .messageFactory(messageFactory())
+            .faultStrategy(ErrorHandlingStrategy.PROPAGATE)
+            .build();
+    }
+
+    @Bean
+    public SaajSoapMessageFactory messageFactory() {
+        return new SaajSoapMessageFactory();
+    }
+
+    @Bean
+    public LoggingClientInterceptor loggingClientInterceptor() {
+        return new LoggingClientInterceptor();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "simulator.mode", havingValue = "embedded")
+    public BeforeSuite startEmbeddedSimulator() {
+        return new SequenceBeforeSuite.Builder().actions(context -> SpringApplication.run(
+            Simulator.class)).build();
+    }
+}

--- a/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/SimulatorNestedWebServiceIT.java
+++ b/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/SimulatorNestedWebServiceIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator;
+
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
+@Test
+@ContextConfiguration(classes = EndpointConfig.class)
+public class SimulatorNestedWebServiceIT extends TestNGCitrusSpringSupport {
+
+    @Autowired
+    private WebServiceClient nestedSimulatorClient;
+
+    @CitrusTest
+    public void testHelloRequest() {
+        $(send(nestedSimulatorClient)
+            .message()
+            .body("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Say Hello!" +
+                "</Hello>")
+            .header("citrus_soap_action", "Hello"));
+
+        $(receive(nestedSimulatorClient)
+            .message()
+            .body("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Hi there!" +
+                "</HelloResponse>"));
+    }
+}

--- a/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/SimulatorWebServiceIT.java
+++ b/simulator-samples/sample-ws/src/test/java/org/citrusframework/simulator/SimulatorWebServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,162 +16,113 @@
 
 package org.citrusframework.simulator;
 
-import org.citrusframework.annotations.CitrusTest;
-import org.citrusframework.container.BeforeSuite;
-import org.citrusframework.container.SequenceBeforeSuite;
-import org.citrusframework.dsl.endpoint.CitrusEndpoints;
-import org.citrusframework.message.ErrorHandlingStrategy;
-import org.citrusframework.simulator.sample.Simulator;
-import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
-import org.citrusframework.ws.client.WebServiceClient;
-import org.citrusframework.ws.interceptor.LoggingClientInterceptor;
-import org.citrusframework.xml.XsdSchemaRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
-import org.testng.annotations.Test;
-
 import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
 import static org.citrusframework.actions.SendMessageAction.Builder.send;
 import static org.citrusframework.validation.xml.XmlMessageValidationContext.Builder.xml;
 import static org.citrusframework.ws.actions.SoapActionBuilder.soap;
 
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
 /**
  * @author Christoph Deppisch
  */
 @Test
-@ContextConfiguration(classes = SimulatorWebServiceIT.EndpointConfig.class)
+@ContextConfiguration(classes = EndpointConfig.class)
 public class SimulatorWebServiceIT extends TestNGCitrusSpringSupport {
 
     @Autowired
-    private WebServiceClient soapClient;
+    private WebServiceClient simulatorClient;
 
     @CitrusTest
     public void testHelloRequest() {
-        $(send(soapClient)
-                .message()
-                .body("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Say Hello!" +
-                         "</Hello>")
-                .header("citrus_soap_action", "Hello"));
+        $(send(simulatorClient)
+            .message()
+            .body("<Hello xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Say Hello!" +
+                "</Hello>")
+            .header("citrus_soap_action", "Hello"));
 
-        $(receive(soapClient)
-                .message()
-                .body("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Hi there!" +
-                         "</HelloResponse>"));
+        $(receive(simulatorClient)
+            .message()
+            .body("<HelloResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Hi there!" +
+                "</HelloResponse>"));
     }
 
     @CitrusTest
     public void testGoodByeRequest() {
-        $(send(soapClient)
-                .message()
-                .body("<GoodBye xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Say GoodBye!" +
-                         "</GoodBye>")
-                .header("citrus_soap_action", "GoodBye"));
+        $(send(simulatorClient)
+            .message()
+            .body("<GoodBye xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Say GoodBye!" +
+                "</GoodBye>")
+            .header("citrus_soap_action", "GoodBye"));
 
-        $(receive(soapClient)
-                .message()
-                .body("<GoodByeResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Bye bye!" +
-                         "</GoodByeResponse>"));
+        $(receive(simulatorClient)
+            .message()
+            .body("<GoodByeResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Bye bye!" +
+                "</GoodByeResponse>"));
     }
 
     @CitrusTest
     public void testGoodNightRequest() {
-        $(send(soapClient)
-                .message()
-                .body("<GoodNight xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Go to sleep!" +
-                         "</GoodNight>")
-                .header("citrus_soap_action", "GoodNight"));
+        $(send(simulatorClient)
+            .message()
+            .body("<GoodNight xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Go to sleep!" +
+                "</GoodNight>")
+            .header("citrus_soap_action", "GoodNight"));
 
-        $(receive(soapClient)
-                .message()
-                .validate(xml().schemaValidation(false))
-                .body("<SOAP-ENV:Fault xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
-                            "<faultcode>CITRUS:SIM-1001</faultcode>\n" +
-                            "<faultstring xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xml:lang=\"en\">" +
-                                "No sleep for me!" +
-                            "</faultstring>\n" +
-                        "</SOAP-ENV:Fault>"));
+        $(receive(simulatorClient)
+            .message()
+            .validate(xml().schemaValidation(false))
+            .body("<SOAP-ENV:Fault xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+                "<faultcode>CITRUS:SIM-1001</faultcode>\n" +
+                "<faultstring xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xml:lang=\"en\">" +
+                "No sleep for me!" +
+                "</faultstring>\n" +
+                "</SOAP-ENV:Fault>"));
 
-        $(send(soapClient)
-                .message()
-                .body("<GoodNight xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Go to sleep!" +
-                        "</GoodNight>")
-                .header("citrus_soap_action", "GoodNight"));
+        $(send(simulatorClient)
+            .message()
+            .body("<GoodNight xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Go to sleep!" +
+                "</GoodNight>")
+            .header("citrus_soap_action", "GoodNight"));
 
-        $(receive(soapClient)
-                .message()
-                .body("<GoodNightResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Good Night!" +
-                        "</GoodNightResponse>"));
+        $(receive(simulatorClient)
+            .message()
+            .body("<GoodNightResponse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Good Night!" +
+                "</GoodNightResponse>"));
     }
 
     @CitrusTest
     public void testUnknownRequest() {
-        $(soap().client(soapClient)
-                .send()
-                .message()
-                .soapAction("SomethingElse")
-                .body("<SomethingElse xmlns=\"http://citrusframework.org/schemas/hello\">" +
-                            "Say something else!" +
-                        "</SomethingElse>"));
+        $(soap().client(simulatorClient)
+            .send()
+            .message()
+            .soapAction("SomethingElse")
+            .body("<SomethingElse xmlns=\"http://citrusframework.org/schemas/hello\">" +
+                "Say something else!" +
+                "</SomethingElse>"));
 
-        $(soap().client(soapClient)
-                .receive()
-                .message()
-                .validate(xml().schemaValidation(false))
-                .body("<SOAP-ENV:Fault xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
-                            "<faultcode>CITRUS:SIM-1100</faultcode>\n" +
-                            "<faultstring xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xml:lang=\"en\">" +
-                                "No matching scenario found" +
-                            "</faultstring>\n" +
-                            "<faultactor>SERVER</faultactor>\n" +
-                        "</SOAP-ENV:Fault>"));
-    }
-
-    @Configuration
-    public static class EndpointConfig {
-
-        @Bean
-        public XsdSchemaRepository schemaRepository() {
-            XsdSchemaRepository schemaRepository = new XsdSchemaRepository();
-            schemaRepository.getLocations().add("classpath:xsd/HelloService.xsd");
-            return schemaRepository;
-        }
-
-        @Bean
-        public WebServiceClient simulatorClient() {
-            return CitrusEndpoints.soap().client()
-                    .defaultUri(String.format("http://localhost:%s/services/ws/simulator", 8080))
-                    .interceptor(loggingClientInterceptor())
-                    .messageFactory(messageFactory())
-                    .faultStrategy(ErrorHandlingStrategy.PROPAGATE)
-                    .build();
-        }
-
-        @Bean
-        public SaajSoapMessageFactory messageFactory() {
-            return new SaajSoapMessageFactory();
-        }
-
-        @Bean
-        public LoggingClientInterceptor loggingClientInterceptor() {
-            return new LoggingClientInterceptor();
-        }
-
-        @Bean
-        @ConditionalOnProperty(name = "simulator.mode", havingValue = "embedded")
-        public BeforeSuite startEmbeddedSimulator() {
-            return new SequenceBeforeSuite.Builder().actions(context -> SpringApplication.run(Simulator.class)).build();
-        }
+        $(soap().client(simulatorClient)
+            .receive()
+            .message()
+            .validate(xml().schemaValidation(false))
+            .body("<SOAP-ENV:Fault xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+                "<faultcode>CITRUS:SIM-1100</faultcode>\n" +
+                "<faultstring xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xml:lang=\"en\">" +
+                "No matching scenario found" +
+                "</faultstring>\n" +
+                "<faultactor>SERVER</faultactor>\n" +
+                "</SOAP-ENV:Fault>"));
     }
 }

--- a/simulator-samples/sample-wsdl/src/main/java/org/citrusframework/simulator/sample/Simulator.java
+++ b/simulator-samples/sample-wsdl/src/main/java/org/citrusframework/simulator/sample/Simulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,17 @@
 
 package org.citrusframework.simulator.sample;
 
+import static java.util.Collections.singletonList;
+
+import java.util.List;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.StaticEndpointAdapter;
 import org.citrusframework.message.Message;
-import org.citrusframework.spi.Resources;
-import org.citrusframework.ws.message.SoapFault;
 import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
 import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
 import org.citrusframework.simulator.ws.WsdlScenarioGenerator;
+import org.citrusframework.spi.Resources;
+import org.citrusframework.ws.message.SoapFault;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -39,13 +42,14 @@ public class Simulator extends SimulatorWebServiceAdapter {
     }
 
     @Override
-    public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
-        return "/services/ws/HelloService/*";
+    public List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+        return singletonList("/services/ws/HelloService/*");
     }
 
     @Override
     public EndpointAdapter fallbackEndpointAdapter() {
         return new StaticEndpointAdapter() {
+
             @Override
             protected Message handleMessageInternal(Message message) {
                 return new SoapFault()
@@ -58,7 +62,6 @@ public class Simulator extends SimulatorWebServiceAdapter {
 
     @Bean
     public static WsdlScenarioGenerator scenarioGenerator() {
-        WsdlScenarioGenerator generator = new WsdlScenarioGenerator(new Resources.ClasspathResource("xsd/Hello.wsdl"));
-        return generator;
+        return new WsdlScenarioGenerator(new Resources.ClasspathResource("xsd/Hello.wsdl"));
     }
 }

--- a/simulator-samples/sample-wsdl/src/main/resources/application.properties
+++ b/simulator-samples/sample-wsdl/src/main/resources/application.properties
@@ -6,18 +6,18 @@ citrus.simulator.ws.enabled=true
 
 # Enable XML data dictionary
 citrus.simulator.inbound.xml.dictionary.enabled=true
-citrus.simulator.inboundXmlDictionary=classpath:dictionary/inbound_mappings.xml
+citrus.simulator.inbound.xml.dictionary.location=classpath:dictionary/inbound_mappings.xml
 citrus.simulator.outbound.xml.dictionary.enabled=true
-citrus.simulator.outboundXmlDictionary=classpath:dictionary/outbound_mappings.xml
+citrus.simulator.outbound.xml.dictionary.location=classpath:dictionary/outbound_mappings.xml
 
 # Default timeout setting
-citrus.simulator.defaultTimeout=5000
+citrus.simulator.default-timeout=5000
 
 # Default message template path
-citrus.simulator.templatePath=templates
+citrus.simulator.template-path=templates
 
 # Default scenario name
 citrus.simulator.defaultScenario=Default
 
 # Should Citrus validate incoming messages on syntax and semantics
-citrus.simulator.templateValidation=true
+citrus.simulator.template-validation=true

--- a/simulator-spring-boot/pom.xml
+++ b/simulator-spring-boot/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <!-- Plugin Management -->
-    <hibernate.version>6.2.7.Final</hibernate.version>
+    <hibernate.version>6.4.1.Final</hibernate.version>
   </properties>
 
   <dependencies>

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package org.citrusframework.simulator.config;
 
-import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
@@ -27,35 +28,19 @@ import org.springframework.core.env.Environment;
  * @author Christoph Deppisch
  */
 @ConfigurationProperties(prefix = "citrus.simulator")
-public class SimulatorConfigurationProperties implements EnvironmentAware {
+public class SimulatorConfigurationProperties implements EnvironmentAware, InitializingBean {
 
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(SimulatorConfigurationProperties.class);
 
-    /**
-     * System property constants and environment variable names. Post construct callback reads these values and overwrites
-     * settings in this property class in order to add support for environment variables.
-     */
-    private static final String SIMULATOR_TEMPLATE_PATH_PROPERTY = "citrus.simulator.template.path";
-    private static final String SIMULATOR_TEMPLATE_PATH_ENV = "CITRUS_SIMULATOR_TEMPLATE_PATH";
-    private static final String SIMULATOR_SCENARIO_PROPERTY = "citrus.simulator.default.scenario";
-    private static final String SIMULATOR_SCENARIO_ENV = "CITRUS_SIMULATOR_DEFAULT_SCENARIO";
-    private static final String SIMULATOR_TIMEOUT_PROPERTY = "citrus.simulator.default.timeout";
-    private static final String SIMULATOR_TIMEOUT_ENV = "CITRUS_SIMULATOR_DEFAULT_TIMEOUT";
-    private static final String SIMULATOR_TEMPLATE_VALIDATION_PROPERTY = "citrus.simulator.template.validation";
-    private static final String SIMULATOR_TEMPLATE_VALIDATION_ENV = "CITRUS_SIMULATOR_TEMPLATE_VALIDATION";
-    private static final String SIMULATOR_EXCEPTION_DELAY_PROPERTY = "citrus.simulator.exception.delay";
-    private static final String SIMULATOR_EXCEPTION_DELAY_ENV = "CITRUS_SIMULATOR_EXCEPTION_DELAY";
-    private static final String SIMULATOR_EXECUTOR_THREADS_PROPERTY = "citrus.simulator.executor.threads";
-    private static final String SIMULATOR_EXECUTOR_THREADS_ENV = "CITRUS_SIMULATOR_EXECUTOR_THREADS";
-    private static final String SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.inbound.xml.dictionary";
-    private static final String SIMULATOR_INBOUND_XML_DICTIONARY_ENV = "CITRUS_SIMULATOR_INBOUND_XML_DICTIONARY";
-    private static final String SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.outbound.xml.dictionary";
-    private static final String SIMULATOR_OUTBOUND_XML_DICTIONARY_ENV = "CITRUS_SIMULATOR_OUTBOUND_XML_DICTIONARY";
-    private static final String SIMULATOR_INBOUND_JSON_DICTIONARY_PROPERTY = "citrus.simulator.inbound.json.dictionary";
-    private static final String SIMULATOR_INBOUND_JSON_DICTIONARY_ENV = "CITRUS_SIMULATOR_INBOUND_JSON_DICTIONARY";
-    private static final String SIMULATOR_OUTBOUND_JSON_DICTIONARY_PROPERTY = "citrus.simulator.outbound.json.dictionary";
-    private static final String SIMULATOR_OUTBOUND_JSON_DICTIONARY_ENV = "CITRUS_SIMULATOR_OUTBOUND_JSON_DICTIONARY";
+    private static final String SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.inbound.xml.dictionary.location";
+    private static final String SIMULATOR_INBOUND_XML_DICTIONARY_ENV = "CITRUS_SIMULATOR_INBOUND_XML_DICTIONARY_LOCATION";
+    private static final String SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY = "citrus.simulator.outbound.xml.dictionary.location";
+    private static final String SIMULATOR_OUTBOUND_XML_DICTIONARY_ENV = "CITRUS_SIMULATOR_OUTBOUND_XML_DICTIONARY_LOCATION";
+    private static final String SIMULATOR_INBOUND_JSON_DICTIONARY_PROPERTY = "citrus.simulator.inbound.json.dictionary.location";
+    private static final String SIMULATOR_INBOUND_JSON_DICTIONARY_ENV = "CITRUS_SIMULATOR_INBOUND_JSON_DICTIONARY_LOCATION";
+    private static final String SIMULATOR_OUTBOUND_JSON_DICTIONARY_PROPERTY = "citrus.simulator.outbound.json.dictionary.location";
+    private static final String SIMULATOR_OUTBOUND_JSON_DICTIONARY_ENV = "CITRUS_SIMULATOR_OUTBOUND_JSON_DICTIONARY_LOCATION";
 
     /**
      * Global option to enable/disable simulator support, default is true.
@@ -112,27 +97,6 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
      * Optional outbound JSON data dictionary mapping file which gets automatically loaded when default outbound data dictionaries are enabled. Used in generated scenarios in order to manipulate generated test data.
      */
     private String outboundJsonDictionary = "outbound-json-dictionary.properties";
-
-     /**
-     * The Spring application context environment auto-injected by environment aware mechanism.
-     */
-    private Environment env;
-
-    @PostConstruct
-    private void loadProperties() {
-        templatePath = env.getProperty(SIMULATOR_TEMPLATE_PATH_PROPERTY, env.getProperty(SIMULATOR_TEMPLATE_PATH_ENV, templatePath));
-        defaultScenario = env.getProperty(SIMULATOR_SCENARIO_PROPERTY, env.getProperty(SIMULATOR_SCENARIO_ENV, defaultScenario));
-        defaultTimeout = Long.valueOf(env.getProperty(SIMULATOR_TIMEOUT_PROPERTY, env.getProperty(SIMULATOR_TIMEOUT_ENV, String.valueOf(defaultTimeout))));
-        templateValidation = Boolean.parseBoolean(env.getProperty(SIMULATOR_TEMPLATE_VALIDATION_PROPERTY, env.getProperty(SIMULATOR_TEMPLATE_VALIDATION_ENV, String.valueOf(templateValidation))));
-        exceptionDelay = Long.valueOf(env.getProperty(SIMULATOR_EXCEPTION_DELAY_PROPERTY, env.getProperty(SIMULATOR_EXCEPTION_DELAY_ENV, String.valueOf(exceptionDelay))));
-        executorThreads = Integer.parseInt(env.getProperty(SIMULATOR_EXECUTOR_THREADS_PROPERTY, env.getProperty(SIMULATOR_EXECUTOR_THREADS_ENV, Integer.toString(executorThreads))));
-        inboundXmlDictionary = env.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_ENV, inboundXmlDictionary));
-        outboundXmlDictionary = env.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_ENV, outboundXmlDictionary));
-        inboundJsonDictionary = env.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_ENV, inboundJsonDictionary));
-        outboundJsonDictionary = env.getProperty(SIMULATOR_OUTBOUND_JSON_DICTIONARY_PROPERTY, env.getProperty(SIMULATOR_OUTBOUND_JSON_DICTIONARY_ENV, outboundJsonDictionary));
-
-        logger.info("Using the simulator configuration: {}", this.toString());
-    }
 
     /**
      * Gets the enabled.
@@ -330,24 +294,32 @@ public class SimulatorConfigurationProperties implements EnvironmentAware {
     }
 
     @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{" +
-                "enabled='" + enabled + '\'' +
-                ", templatePath='" + templatePath + '\'' +
-                ", defaultScenario='" + defaultScenario + '\'' +
-                ", defaultTimeout=" + defaultTimeout +
-                ", exceptionDelay=" + exceptionDelay +
-                ", executorThreads=" + executorThreads +
-                ", templateValidation=" + templateValidation +
-                ", inboundXmlDictionary=" + inboundXmlDictionary +
-                ", outboundXmlDictionary=" + outboundXmlDictionary +
-                ", inboundJsonDictionary=" + inboundJsonDictionary +
-                ", outboundJsonDictionary=" + outboundJsonDictionary +
-                '}';
+    public void setEnvironment(Environment environment) {
+        inboundXmlDictionary = environment.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_PROPERTY, environment.getProperty(SIMULATOR_INBOUND_XML_DICTIONARY_ENV, inboundXmlDictionary));
+        outboundXmlDictionary = environment.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_PROPERTY, environment.getProperty(SIMULATOR_OUTBOUND_XML_DICTIONARY_ENV, outboundXmlDictionary));
+        inboundJsonDictionary = environment.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_PROPERTY, environment.getProperty(SIMULATOR_INBOUND_JSON_DICTIONARY_ENV, inboundJsonDictionary));
+        outboundJsonDictionary = environment.getProperty(SIMULATOR_OUTBOUND_JSON_DICTIONARY_PROPERTY, environment.getProperty(SIMULATOR_OUTBOUND_JSON_DICTIONARY_ENV, outboundJsonDictionary));
+  }
+
+    @Override
+    public void afterPropertiesSet() {
+        logger.info("Using the simulator configuration: {}", this);
     }
 
     @Override
-    public void setEnvironment(Environment environment) {
-        this.env = environment;
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append(enabled)
+            .append(templatePath)
+            .append(defaultScenario)
+            .append(defaultTimeout)
+            .append(exceptionDelay)
+            .append(executorThreads)
+            .append(templateValidation)
+            .append(inboundXmlDictionary)
+            .append(outboundXmlDictionary)
+            .append(inboundJsonDictionary)
+            .append(outboundJsonDictionary)
+            .toString();
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/http/HttpScenarioGenerator.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/http/HttpScenarioGenerator.java
@@ -1,14 +1,34 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.simulator.http;
+
+import static org.citrusframework.util.FileUtils.readToString;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
+import java.io.IOException;
+import java.util.Map;
 import org.citrusframework.simulator.exception.SimulatorException;
 import org.citrusframework.spi.CitrusResourceWrapper;
 import org.citrusframework.spi.Resource;
-import org.citrusframework.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -16,13 +36,9 @@ import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.core.env.Environment;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -33,17 +49,12 @@ public class HttpScenarioGenerator implements BeanFactoryPostProcessor {
      * Logger
      */
     private static final Logger logger = LoggerFactory.getLogger(HttpScenarioGenerator.class);
-    /**
-     * Optional Swagger api file location system property for auto generated scenarios
-     */
-    private static final String SIMULATOR_SWAGGER_API_PROPERTY = "citrus.simulator.rest.swagger.api";
-    private static final String SIMULATOR_SWAGGER_API_ENV = "CITRUS_SIMULATOR_REST_SWAGGER_API";
-    private static final String SIMULATOR_SWAGGER_CONTEXT_PATH_PROPERTY = "citrus.simulator.rest.swagger.contextPath";
-    private static final String SIMULATOR_SWAGGER_CONTEXT_PATH_ENV = "CITRUS_SIMULATOR_REST_SWAGGER_CONTEXT_PATH";
+
     /**
      * Target swagger API to generate scenarios from
      */
     private final Resource swaggerResource;
+
     /**
      * Optional context path
      */
@@ -52,11 +63,13 @@ public class HttpScenarioGenerator implements BeanFactoryPostProcessor {
     /**
      * Constructor using Spring environment.
      */
-    public HttpScenarioGenerator(Environment environment) {
-        org.springframework.core.io.Resource springResource = new PathMatchingResourcePatternResolver().getResource(environment.getProperty(SIMULATOR_SWAGGER_API_PROPERTY, environment.getProperty(SIMULATOR_SWAGGER_API_ENV, "")));
-        swaggerResource = new CitrusResourceWrapper(springResource);
+    public HttpScenarioGenerator(SimulatorRestConfigurationProperties simulatorRestConfigurationProperties) {
+        swaggerResource = new CitrusResourceWrapper(
+            new PathMatchingResourcePatternResolver()
+                .getResource(simulatorRestConfigurationProperties.getSwagger().getApi())
+        );
 
-        contextPath = environment.getProperty(SIMULATOR_SWAGGER_CONTEXT_PATH_PROPERTY, environment.getProperty(SIMULATOR_SWAGGER_CONTEXT_PATH_ENV, contextPath));
+        contextPath = simulatorRestConfigurationProperties.getSwagger().getContextPath();
     }
 
     /**
@@ -74,14 +87,15 @@ public class HttpScenarioGenerator implements BeanFactoryPostProcessor {
             Assert.notNull(swaggerResource,
                 "Missing either swagger api system property setting or explicit swagger api resource for scenario auto generation");
 
-            Swagger swagger = new SwaggerParser().parse(FileUtils.readToString(swaggerResource));
+            Swagger swagger = new SwaggerParser().parse(readToString(swaggerResource));
 
             for (Map.Entry<String, Path> path : swagger.getPaths().entrySet()) {
                 for (Map.Entry<io.swagger.models.HttpMethod, Operation> operation : path.getValue().getOperationMap().entrySet()) {
 
-                    if (beanFactory instanceof BeanDefinitionRegistry) {
-                        logger.info("Register auto generated scenario as bean definition: " + operation.getValue().getOperationId());
-                        BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(HttpOperationScenario.class)
+                    if (beanFactory instanceof BeanDefinitionRegistry beanDefinitionRegistry) {
+                        logger.info("Register auto generated scenario as bean definition: {}", operation.getValue().getOperationId());
+
+                        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(HttpOperationScenario.class)
                             .addConstructorArgValue((contextPath + (swagger.getBasePath() != null ? swagger.getBasePath() : "")) + path.getKey())
                             .addConstructorArgValue(RequestMethod.valueOf(operation.getKey().name()))
                             .addConstructorArgValue(operation.getValue())
@@ -95,9 +109,9 @@ public class HttpScenarioGenerator implements BeanFactoryPostProcessor {
                             beanDefinitionBuilder.addPropertyReference("outboundDataDictionary", "outboundJsonDataDictionary");
                         }
 
-                        ((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(operation.getValue().getOperationId(), beanDefinitionBuilder.getBeanDefinition());
+                        beanDefinitionRegistry.registerBeanDefinition(operation.getValue().getOperationId(), beanDefinitionBuilder.getBeanDefinition());
                     } else {
-                        logger.info("Register auto generated scenario as singleton: " + operation.getValue().getOperationId());
+                        logger.info("Register auto generated scenario as singleton: {}", operation.getValue().getOperationId());
                         beanFactory.registerSingleton(operation.getValue().getOperationId(), createScenario((contextPath + (swagger.getBasePath() != null ? swagger.getBasePath() : "")) + path.getKey(), RequestMethod.valueOf(operation.getKey().name()), operation.getValue(), swagger.getDefinitions()));
                     }
                 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/http/SimulatorRestAutoConfiguration.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/http/SimulatorRestAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,11 @@ package org.citrusframework.simulator.http;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.EmptyResponseEndpointAdapter;
 import org.citrusframework.http.controller.HttpMessageController;
@@ -41,7 +46,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.core.env.Environment;
 import org.springframework.web.servlet.HandlerAdapter;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
@@ -50,12 +54,6 @@ import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -208,8 +206,8 @@ public class SimulatorRestAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(HttpScenarioGenerator.class)
     @ConditionalOnProperty(prefix = "citrus.simulator.rest.swagger", value = "enabled", havingValue = "true")
-    public static HttpScenarioGenerator simulatorRestScenarioGenerator(Environment environment) {
-        return new HttpScenarioGenerator(environment);
+    public HttpScenarioGenerator simulatorRestScenarioGenerator() {
+        return new HttpScenarioGenerator(simulatorRestConfiguration);
     }
 
     /**

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/jms/SimulatorJmsConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/jms/SimulatorJmsConfigurationProperties.java
@@ -1,40 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.simulator.jms;
 
-import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Christoph Deppisch
  */
 @ConfigurationProperties(prefix = "citrus.simulator.jms")
-public class SimulatorJmsConfigurationProperties implements EnvironmentAware {
+public class SimulatorJmsConfigurationProperties implements InitializingBean {
 
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(SimulatorJmsConfigurationProperties.class);
 
     /**
-     * System property constants and environment variable names. Post construct callback reads these values and overwrites
-     * settings in this property class in order to add support for environment variables.
-     */
-    private static final String SIMULATOR_INBOUND_DESTINATION_PROPERTY = "citrus.simulator.jms.inbound.destination";
-    private static final String SIMULATOR_INBOUND_DESTINATION_ENV = "CITRUS_SIMULATOR_JMS_INBOUND_DESTINATION";
-    private static final String SIMULATOR_REPLY_DESTINATION_PROPERTY = "citrus.simulator.jms.reply.destination";
-    private static final String SIMULATOR_REPLY_DESTINATION_ENV = "CITRUS_SIMULATOR_JMS_REPLY_DESTINATION";
-    private static final String SIMULATOR_SYNC_PROPERTY = "citrus.simulator.jms.synchronous";
-    private static final String SIMULATOR_SYNC_ENV = "CITRUS_SIMULATOR_JMS_SYNCHRONOUS";
-    private static final String SIMULATOR_SOAP_ENVELOPE_PROPERTY = "citrus.simulator.jms.soap";
-    private static final String SIMULATOR_SOAP_ENVELOPE_ENV = "CITRUS_SIMULATOR_JMS_SOAP";
-    private static final String SIMULATOR_PUB_SUB_DOMAIN_PROPERTY = "citrus.simulator.jms.pub.sub.domain";
-    private static final String SIMULATOR_PUB_SUB_DOMAIN_ENV = "CITRUS_SIMULATOR_JMS_PUB_SUB_DOMAIN";
-
-    /**
      * Global option to enable/disable JMS support, default is false.
      */
-    private boolean enabled;
+    private boolean enabled = false;
 
     /**
      * The JMS inbound destination name. The simulator receives asynchronous messages using this destination.
@@ -47,35 +47,19 @@ public class SimulatorJmsConfigurationProperties implements EnvironmentAware {
     private String replyDestination = "";
 
     /**
-     * En-/Disable JMS synchronous communication. By default this option is disabled.
+     * En-/Disable JMS synchronous communication. By default, this option is disabled.
      */
     private boolean synchronous = false;
 
     /**
-     * En-/Disable JMS synchronous communication. By default this option is disabled.
+     * En-/Disable JMS synchronous communication. By default, this option is disabled.
      */
     private boolean useSoap = false;
 
     /**
-     * Pub-Sum Domain . By default this option is disabled.
+     * Pub-Sum Domain. By default, this option is disabled.
      */
     private boolean pubSubDomain = false;
-
-    /**
-     * The Spring application context environment auto injected by environment aware mechanism.
-     */
-    private Environment env;
-
-    @PostConstruct
-    private void loadProperties() {
-        inboundDestination = env.getProperty(SIMULATOR_INBOUND_DESTINATION_PROPERTY, env.getProperty(SIMULATOR_INBOUND_DESTINATION_ENV, inboundDestination));
-        replyDestination = env.getProperty(SIMULATOR_REPLY_DESTINATION_PROPERTY, env.getProperty(SIMULATOR_REPLY_DESTINATION_ENV, replyDestination));
-        synchronous = Boolean.parseBoolean(env.getProperty(SIMULATOR_SYNC_PROPERTY, env.getProperty(SIMULATOR_SYNC_ENV, String.valueOf(synchronous))));
-        useSoap = Boolean.parseBoolean(env.getProperty(SIMULATOR_SOAP_ENVELOPE_PROPERTY, env.getProperty(SIMULATOR_SOAP_ENVELOPE_ENV, String.valueOf(useSoap))));
-        pubSubDomain = Boolean.parseBoolean(env.getProperty(SIMULATOR_PUB_SUB_DOMAIN_PROPERTY, env.getProperty(SIMULATOR_PUB_SUB_DOMAIN_ENV, String.valueOf(pubSubDomain))));
-
-        logger.info("Using the simulator configuration: {}", this.toString());
-    }
 
     /**
      * Gets the enabled.
@@ -186,19 +170,19 @@ public class SimulatorJmsConfigurationProperties implements EnvironmentAware {
     }
 
     @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{" +
-                "enabled='" + enabled + '\'' +
-                ", inboundDestination='" + inboundDestination + '\'' +
-                ", replyDestination='" + replyDestination + '\'' +
-                ", synchronous='" + synchronous + '\'' +
-                ", useSoap='" + useSoap + '\'' +
-                ", pubSubDomain='" + pubSubDomain + '\'' +
-                '}';
+    public void afterPropertiesSet() {
+        logger.info("Using the simulator configuration: {}", this);
     }
 
     @Override
-    public void setEnvironment(Environment environment) {
-        this.env = environment;
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append(enabled)
+            .append(inboundDestination)
+            .append(replyDestination)
+            .append(synchronous)
+            .append(useSoap)
+            .append(pubSubDomain)
+            .toString();
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/model/TestParameter.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/model/TestParameter.java
@@ -32,6 +32,8 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
+import static java.util.Objects.hash;
+
 /**
  * Represents a parameter of a test result, holding a key-value pair of parameter details. It is linked to
  * a {@link org.citrusframework.simulator.model.TestResult} entity through a many-to-one relationship, where
@@ -193,6 +195,11 @@ public class TestParameter extends AbstractAuditingEntity<TestParameter, TestPar
                 return key != null && testResultId != null && key.equals(testParameterId.key) && testResultId.equals(testParameterId.testResultId);
             }
             return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash(key, testResultId);
         }
     }
 

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAdapter.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.citrusframework.simulator.ws;
 
+import java.util.List;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.EmptyResponseEndpointAdapter;
 import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
@@ -28,8 +29,8 @@ import org.citrusframework.simulator.scenario.mapper.ScenarioMapper;
 public abstract class SimulatorWebServiceAdapter implements SimulatorWebServiceConfigurer {
 
     @Override
-    public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
-        return simulatorWebServiceConfiguration.getServletMapping();
+    public List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+        return simulatorWebServiceConfiguration.getServletMappings();
     }
 
     @Override

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAutoConfiguration.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAutoConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.simulator.ws;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.endpoint.adapter.EmptyResponseEndpointAdapter;
 import org.citrusframework.simulator.SimulatorAutoConfiguration;
@@ -36,7 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
-import org.springframework.core.env.Environment;
 import org.springframework.ws.config.annotation.WsConfigurationSupport;
 import org.springframework.ws.server.EndpointInterceptor;
 import org.springframework.ws.server.EndpointMapping;
@@ -44,10 +46,6 @@ import org.springframework.ws.server.endpoint.MessageEndpoint;
 import org.springframework.ws.server.endpoint.adapter.MessageEndpointAdapter;
 import org.springframework.ws.server.endpoint.mapping.UriEndpointMapping;
 import org.springframework.ws.transport.http.MessageDispatcherServlet;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * @author Christoph Deppisch
@@ -148,8 +146,8 @@ public class SimulatorWebServiceAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(WsdlScenarioGenerator.class)
     @ConditionalOnProperty(prefix = "citrus.simulator.ws.wsdl", value = "enabled", havingValue = "true")
-    public static WsdlScenarioGenerator simulatorWsdlScenarioGenerator(Environment environment) {
-        return new WsdlScenarioGenerator(environment);
+    public WsdlScenarioGenerator simulatorWsdlScenarioGenerator() {
+        return new WsdlScenarioGenerator(simulatorWebServiceConfiguration);
     }
 
     /**

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAutoConfiguration.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,12 +158,12 @@ public class SimulatorWebServiceAutoConfiguration {
      *
      * @return
      */
-    protected String getServletMapping() {
+    protected String[] getServletMapping() {
         if (configurer != null) {
-            return configurer.servletMapping(simulatorWebServiceConfiguration);
+            return configurer.servletMappings(simulatorWebServiceConfiguration).toArray(new String[0]);
         }
 
-        return simulatorWebServiceConfiguration.getServletMapping();
+        return simulatorWebServiceConfiguration.getServletMappings().toArray(new String[0]);
     }
 
     /**

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceClientConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceClientConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,53 +16,32 @@
 
 package org.citrusframework.simulator.ws;
 
-import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Martin Maher
  */
 @ConfigurationProperties(prefix = "citrus.simulator.ws.client")
-public class SimulatorWebServiceClientConfigurationProperties implements EnvironmentAware {
+public class SimulatorWebServiceClientConfigurationProperties implements InitializingBean {
+
     /**
      * Logger
      */
     private static final Logger logger = LoggerFactory.getLogger(SimulatorWebServiceClientConfigurationProperties.class);
 
     /**
-     * System property constants and environment variable names. Post construct callback reads these values and overwrites
-     * settings in this property class in order to add support for environment variables.
-     */
-    private static final String SIMULATOR_WSCLIENT_REQUEST_URL_PROPERTY = "citrus.simulator.ws.client.request.url";
-    private static final String SIMULATOR_WSCLIENT_REQUEST_URL_ENV = "SIMULATOR_WS_CLIENT_REQUEST_URL";
-
-    /**
      * Global option to enable/disable SOAP web service client support, default is false.
      */
-    private boolean enabled;
+    private boolean enabled = false;
 
     /**
      * SOAP server endpoint URL. This is where the SOAP client sends its requests to.
      */
     private String requestUrl = "http://localhost:8080/services/ws/simulator";
-
-    /**
-     * The Spring application context environment auto injected by environment aware mechanism.
-     */
-    private Environment env;
-
-    @PostConstruct
-    private void loadProperties() {
-        requestUrl = env.getProperty(SIMULATOR_WSCLIENT_REQUEST_URL_PROPERTY,
-                env.getProperty(SIMULATOR_WSCLIENT_REQUEST_URL_ENV, requestUrl)
-        );
-
-        logger.info("Using the simulator configuration: {}", this.toString());
-    }
 
     /**
      * Gets the enabled.
@@ -101,15 +80,15 @@ public class SimulatorWebServiceClientConfigurationProperties implements Environ
     }
 
     @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{" +
-                "enabled='" + enabled + '\'' +
-                ", requestUrl='" + requestUrl + '\'' +
-                '}';
+    public void afterPropertiesSet() {
+        logger.info("Using the simulator configuration: {}", this);
     }
 
     @Override
-    public void setEnvironment(Environment environment) {
-        this.env = environment;
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append(enabled)
+            .append(requestUrl)
+            .toString();
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
@@ -16,9 +16,10 @@
 
 package org.citrusframework.simulator.ws;
 
-import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
@@ -29,7 +30,7 @@ import static java.util.Collections.singletonList;
  * @author Christoph Deppisch
  */
 @ConfigurationProperties(prefix = "citrus.simulator.ws")
-public class SimulatorWebServiceConfigurationProperties {
+public class SimulatorWebServiceConfigurationProperties implements InitializingBean {
 
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(SimulatorWebServiceConfigurationProperties.class);
@@ -37,7 +38,7 @@ public class SimulatorWebServiceConfigurationProperties {
     /**
      * Global option to enable/disable SOAP web service support, default is false.
      */
-    private boolean enabled;
+    private boolean enabled = false;
 
     /**
      * The web service message dispatcher servlet mapping. Clients must use this
@@ -45,10 +46,7 @@ public class SimulatorWebServiceConfigurationProperties {
      */
     private List<String> servletMappings = singletonList("/services/ws/*");
 
-    @PostConstruct
-    private void loadProperties() {
-        logger.info("Using the simulator configuration: {}", this);
-    }
+    private Wsdl wsdl = new Wsdl();
 
     /**
      * Gets the enabled.
@@ -69,7 +67,7 @@ public class SimulatorWebServiceConfigurationProperties {
     }
 
     /**
-     * Gets the servletMapping.
+     * Gets the servletMappings.
      *
      * @return
      */
@@ -78,7 +76,7 @@ public class SimulatorWebServiceConfigurationProperties {
     }
 
     /**
-     * Sets the servletMapping.
+     * Sets the servletMappings.
      *
      * @param servletMappings
      */
@@ -86,11 +84,55 @@ public class SimulatorWebServiceConfigurationProperties {
         this.servletMappings = servletMappings;
     }
 
+    public Wsdl getWsdl() {
+        return wsdl;
+    }
+
+    public void setWsdl(Wsdl wsdl) {
+        this.wsdl = wsdl;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        logger.info("Using the simulator configuration: {}", this);
+    }
+
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + "{" +
-                "enabled='" + enabled + '\'' +
-                ", servletMappings=" + servletMappings +
-                '}';
+        return new ToStringBuilder(this)
+            .append(enabled)
+            .append(servletMappings)
+            .append(wsdl)
+            .toString();
+    }
+
+    public static class Wsdl {
+
+        private boolean enabled;
+        private String location;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                .append(enabled)
+                .append(location)
+                .toString();
+        }
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,24 +20,19 @@ import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.Environment;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
 
 /**
  * @author Christoph Deppisch
  */
 @ConfigurationProperties(prefix = "citrus.simulator.ws")
-public class SimulatorWebServiceConfigurationProperties implements EnvironmentAware {
+public class SimulatorWebServiceConfigurationProperties {
 
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(SimulatorWebServiceConfigurationProperties.class);
-
-    /**
-     * System property constants and environment variable names. Post construct callback reads these values and overwrites
-     * settings in this property class in order to add support for environment variables.
-     */
-    private static final String SIMULATOR_SERVLET_MAPPING_PROPERTY = "citrus.simulator.ws.servlet.mapping";
-    private static final String SIMULATOR_SERVLET_MAPPING_ENV = "CITRUS_SIMULATOR_WS_SERVLET_MAPPING";
 
     /**
      * Global option to enable/disable SOAP web service support, default is false.
@@ -48,18 +43,11 @@ public class SimulatorWebServiceConfigurationProperties implements EnvironmentAw
      * The web service message dispatcher servlet mapping. Clients must use this
      * context path in order to access the web service support on the simulator.
      */
-    private String servletMapping = "/services/ws/*";
-
-    /**
-     * The Spring application context environment auto injected by environment aware mechanism.
-     */
-    private Environment env;
+    private List<String> servletMappings = singletonList("/services/ws/*");
 
     @PostConstruct
     private void loadProperties() {
-        servletMapping = env.getProperty(SIMULATOR_SERVLET_MAPPING_PROPERTY, env.getProperty(SIMULATOR_SERVLET_MAPPING_ENV, servletMapping));
-
-        logger.info("Using the simulator configuration: {}", this.toString());
+        logger.info("Using the simulator configuration: {}", this);
     }
 
     /**
@@ -85,29 +73,24 @@ public class SimulatorWebServiceConfigurationProperties implements EnvironmentAw
      *
      * @return
      */
-    public String getServletMapping() {
-        return servletMapping;
+    public List<String> getServletMappings() {
+        return servletMappings;
     }
 
     /**
      * Sets the servletMapping.
      *
-     * @param servletMapping
+     * @param servletMappings
      */
-    public void setServletMapping(String servletMapping) {
-        this.servletMapping = servletMapping;
+    public void setServletMappings(List<String> servletMappings) {
+        this.servletMappings = servletMappings;
     }
 
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "{" +
                 "enabled='" + enabled + '\'' +
-                ", servletMapping='" + servletMapping + '\'' +
+                ", servletMappings=" + servletMappings +
                 '}';
-    }
-
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.env = environment;
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurer.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/SimulatorWebServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.citrusframework.simulator.ws;
 
+import java.util.List;
 import org.citrusframework.simulator.config.SimulatorConfigurer;
 import org.springframework.ws.server.EndpointInterceptor;
 
@@ -29,7 +30,7 @@ public interface SimulatorWebServiceConfigurer extends SimulatorConfigurer {
      *
      * @return
      */
-    String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration);
+    List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration);
 
     /**
      * Gets the list of endpoint interceptors.

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/WsdlScenarioGenerator.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/ws/WsdlScenarioGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.simulator.ws;
 
 import org.apache.xmlbeans.SchemaType;
@@ -20,7 +36,6 @@ import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.core.env.Environment;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -48,12 +63,6 @@ public class WsdlScenarioGenerator implements BeanFactoryPostProcessor {
     private static final Logger logger = LoggerFactory.getLogger(WsdlScenarioGenerator.class);
 
     /**
-     * Optional WSDL file location system property for auto generated scenarios
-     */
-    private static final String SIMULATOR_WSDL_LOCATION_PROPERTY = "citrus.simulator.ws.wsdl.location";
-    private static final String SIMULATOR_WSDL_LOCATION_ENV = "CITRUS_SIMULATOR_WS_WSDL_LOCATION";
-
-    /**
      * Target wsdl to generate scenarios from
      */
     private final Resource wsdlResource;
@@ -66,9 +75,11 @@ public class WsdlScenarioGenerator implements BeanFactoryPostProcessor {
     /**
      * Default constructor.
      */
-    public WsdlScenarioGenerator(Environment environment) {
-        org.springframework.core.io.Resource springResource = new PathMatchingResourcePatternResolver().getResource(environment.getProperty(SIMULATOR_WSDL_LOCATION_PROPERTY, environment.getProperty(SIMULATOR_WSDL_LOCATION_ENV, "")));
-        wsdlResource = new CitrusResourceWrapper(springResource);
+    public WsdlScenarioGenerator(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationProperties) {
+        wsdlResource = new CitrusResourceWrapper(
+            new PathMatchingResourcePatternResolver()
+                .getResource(simulatorWebServiceConfigurationProperties.getWsdl().getLocation())
+        );
     }
 
     /**

--- a/simulator-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/simulator-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,40 +13,16 @@
       "defaultValue": "org.citrusframework.simulator.SimulatorConfig"
     },
     {
-      "name": "citrus.simulator.rest.swagger.enabled",
-      "type": "java.lang.Boolean",
-      "description": "En/Disables auto generated scenarios from Swagger Open API specification.",
-      "defaultValue": false
-    },
-    {
-      "name": "citrus.simulator.rest.swagger.api",
-      "type": "java.lang.String",
-      "description": "Swagger Open API specification file to auto generate scenarios from.",
-      "defaultValue": ""
-    },
-    {
-      "name": "citrus.simulator.rest.swagger.contextPath",
-      "type": "java.lang.String",
-      "description": "Context path automatically added to request path mappings when using auto generate scenarios from Swagger Open API specification.",
-      "defaultValue": ""
-    },
-    {
-      "name": "citrus.simulator.ws.wsdl.enabled",
-      "type": "java.lang.Boolean",
-      "description": "En/Disables auto generated scenarios from WSDL specification.",
-      "defaultValue": false
-    },
-    {
-      "name": "citrus.simulator.ws.wsdl.location",
-      "type": "java.lang.String",
-      "description": "WSDL file to auto generate scenarios from.",
-      "defaultValue": ""
-    },
-    {
       "name": "citrus.simulator.inbound.xml.dictionary.enabled",
       "type": "java.lang.Boolean",
       "description": "En/Disables default inbound XML data dictionaries.",
       "defaultValue": false
+    },
+    {
+      "name": "citrus.simulator.inbound.xml.dictionary.location",
+      "type": "java.lang.String",
+      "description": "Location of the inbound XML data dictionaries.",
+      "defaultValue": "inbound-xml-dictionary.xml"
     },
     {
       "name": "citrus.simulator.outbound.xml.dictionary.enabled",
@@ -55,16 +31,28 @@
       "defaultValue": false
     },
     {
+      "name": "citrus.simulator.outbound.xml.dictionary.location",
+      "type": "java.lang.Boolean",
+      "description": "Location of the outbound XML data dictionaries.",
+      "defaultValue": "outbound-xml-dictionary.xml"
+    },
+    {
       "name": "citrus.simulator.inbound.json.dictionary.enabled",
       "type": "java.lang.Boolean",
       "description": "En/Disables default inbound JSON data dictionaries.",
       "defaultValue": false
     },
     {
+      "name": "citrus.simulator.inbound.json.dictionary.location",
+      "type": "java.lang.Boolean",
+      "description": "Location of the inbound JSON data dictionaries.",
+      "defaultValue": "inbound-json-dictionary.properties"
+    },
+    {
       "name": "citrus.simulator.outbound.json.dictionary.enabled",
       "type": "java.lang.Boolean",
-      "description": "En/Disables default outbound JSON data dictionaries.",
-      "defaultValue": false
+      "description": "Location of the outbound JSON data dictionaries.",
+      "defaultValue": "outbound-json-dictionary.properties"
     }
   ]
 }

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/model/TestParameterIdTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/model/TestParameterIdTest.java
@@ -1,0 +1,34 @@
+package org.citrusframework.simulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestParameterIdTest {
+
+    @Test
+    void equalsVerifier() throws Exception {
+        EntityTestUtils.equalsVerifier(TestParameter.TestParameterId.class);
+
+        TestResult testResult1 = TestResult.builder().id(1L).build();
+
+        TestParameter.TestParameterId testParameterId1 = new TestParameter.TestParameterId("key", testResult1);
+
+        TestParameter.TestParameterId testParameterId2 = new TestParameter.TestParameterId(testParameterId1.key, testResult1);
+        assertThat(testParameterId1).isEqualTo(testParameterId2);
+
+        testParameterId2.key = "key-2";
+        assertThat(testParameterId1).isNotEqualTo(testParameterId2);
+
+        testParameterId2.key = testParameterId1.key;
+        testParameterId2.testResultId = 2L;
+        assertThat(testParameterId1).isNotEqualTo(testParameterId2);
+
+        testParameterId1.testResultId = null;
+        assertThat(testParameterId1).isNotEqualTo(testParameterId2);
+
+        testParameterId1.key = null;
+        testParameterId1.testResultId = testResult1.getId();
+        assertThat(testParameterId1).isNotEqualTo(testParameterId2);
+    }
+}

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/model/TestParameterTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/model/TestParameterTest.java
@@ -1,9 +1,9 @@
 package org.citrusframework.simulator.model;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 class TestParameterTest {
 
@@ -16,10 +16,10 @@ class TestParameterTest {
 
         assertThat(testParameter1).isEqualTo(testParameter2);
 
-        ReflectionTestUtils.setField(testParameter2, "testParameterId", new TestParameter.TestParameterId("key-2", testParameter1.getTestResult()), TestParameter.TestParameterId.class);
+        setField(testParameter2, "testParameterId", new TestParameter.TestParameterId("key-2", testParameter1.getTestResult()), TestParameter.TestParameterId.class);
         assertThat(testParameter1).isNotEqualTo(testParameter2);
 
-        ReflectionTestUtils.setField(testParameter2, "testParameterId", new TestParameter.TestParameterId(testParameter1.getKey(), TestResult.builder().id(2L).build()), TestParameter.TestParameterId.class);
+        setField(testParameter2, "testParameterId", new TestParameter.TestParameterId(testParameter1.getKey(), TestResult.builder().id(2L).build()), TestParameter.TestParameterId.class);
         assertThat(testParameter1).isNotEqualTo(testParameter2);
 
         testParameter1.setTestResult(null);

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/ws/SimulatorWebServiceAdapterTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/ws/SimulatorWebServiceAdapterTest.java
@@ -1,0 +1,64 @@
+package org.citrusframework.simulator.ws;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import org.citrusframework.endpoint.adapter.EmptyResponseEndpointAdapter;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
+import org.citrusframework.simulator.scenario.mapper.ContentBasedXPathScenarioMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SimulatorWebServiceAdapterTest {
+
+    @Mock
+    private SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationProperties;
+
+    @Mock
+    private SimulatorConfigurationProperties simulatorConfigurationProperties;
+
+    private SimulatorWebServiceAdapter fixture;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new SimulatorWebServiceAdapter() {
+        };
+    }
+
+    @Test
+    void testServletMappings() {
+        doReturn(asList("/path1", "/path2")).when(simulatorWebServiceConfigurationProperties).getServletMappings();
+
+        assertThat(fixture.servletMappings(simulatorWebServiceConfigurationProperties))
+            .hasSize(2)
+            .containsExactly("/path1", "/path2");
+    }
+
+    @Test
+    void testScenarioMapper() {
+        assertThat(fixture.scenarioMapper())
+            .isNotNull()
+            .isInstanceOf(ContentBasedXPathScenarioMapper.class);
+    }
+
+    @Test
+    void testFallbackEndpointAdapter() {
+        assertThat(fixture.fallbackEndpointAdapter())
+            .isNotNull()
+            .isInstanceOf(EmptyResponseEndpointAdapter.class);
+    }
+
+    @Test
+    void testExceptionDelay() {
+        doReturn(1000L).when(simulatorConfigurationProperties).getExceptionDelay();
+
+        assertThat(fixture.exceptionDelay(simulatorConfigurationProperties))
+            .isNotNull()
+            .isEqualTo(1000L);
+    }
+}

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.citrusframework.simulator.ui.config;
 
+import static java.util.Objects.nonNull;
+
 import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import org.citrusframework.simulator.http.SimulatorRestAdapter;
 import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
 import org.citrusframework.simulator.ui.filter.SpaWebFilter;
@@ -37,10 +41,6 @@ import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWrite
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 @Configuration
 public class SecurityConfiguration {
@@ -146,21 +146,21 @@ public class SecurityConfiguration {
     }
 
     private void addWebServiceMatchers(List<String> urlMappings) {
-        if (!Objects.isNull(simulatorWebServiceConfigurationProperties)
-            && !Objects.isNull(simulatorWebServiceAdapter)
-            && simulatorWebServiceAdapter.servletMapping(simulatorWebServiceConfigurationProperties) != null) {
-            urlMappings.add(simulatorWebServiceAdapter.servletMapping(simulatorWebServiceConfigurationProperties));
-        } else if (!Objects.isNull(simulatorWebServiceConfigurationProperties)
-            && simulatorWebServiceConfigurationProperties.getServletMapping() != null) {
-            urlMappings.add(simulatorWebServiceConfigurationProperties.getServletMapping());
+        if (nonNull(simulatorWebServiceConfigurationProperties)
+            && nonNull(simulatorWebServiceAdapter)
+            && simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties) != null) {
+            urlMappings.addAll(simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties));
+        } else if (nonNull(simulatorWebServiceConfigurationProperties)
+            && simulatorWebServiceConfigurationProperties.getServletMappings() != null) {
+            urlMappings.addAll(simulatorWebServiceConfigurationProperties.getServletMappings());
         }
     }
 
     private void addRestMatchers(List<String> urlMappings) {
-        if (!Objects.isNull(simulatorRestConfigurationProperties)
-            && !Objects.isNull(simulatorRestAdapter)) {
+        if (nonNull(simulatorRestConfigurationProperties)
+            && nonNull(simulatorRestAdapter)) {
             urlMappings.addAll(simulatorRestAdapter.urlMappings(simulatorRestConfigurationProperties));
-        } else if (!Objects.isNull(simulatorRestConfigurationProperties)) {
+        } else if (nonNull(simulatorRestConfigurationProperties)) {
             urlMappings.addAll(simulatorRestConfigurationProperties.getUrlMappings());
         }
     }

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SecurityConfigurationWithAdaptersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
 
+import static java.util.Collections.singletonList;
+
 /**
  * @author Thorsten Schlathoelter
  */
@@ -55,7 +57,7 @@ class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationI
             return new SimulatorRestAdapter() {
                 @Override
                 public List<String> urlMappings(SimulatorRestConfigurationProperties simulatorRestConfiguration) {
-                    return List.of("/modified-simulator/rest/**");
+                    return singletonList("/modified-simulator/rest/**");
                 }
             };
         }
@@ -64,8 +66,9 @@ class SecurityConfigurationWithAdaptersIT extends AbstractSecurityConfigurationI
         @ConditionalOnProperty(name = "with-adapters", havingValue = "true")
         public SimulatorWebServiceAdapter simulatorWebServiceAdapter() {
             return new SimulatorWebServiceAdapter() {
-                public String servletMapping(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
-                    return "/modified-simulator/ws/*";
+                @Override
+                public List<String> servletMappings(SimulatorWebServiceConfigurationProperties simulatorWebServiceConfiguration) {
+                    return singletonList("/modified-simulator/ws/*");
                 }
             };
         }

--- a/simulator-ui/src/test/resources/application.properties
+++ b/simulator-ui/src/test/resources/application.properties
@@ -2,4 +2,4 @@ citrus.simulator.rest.enabled=true
 citrus.simulator.rest.url-mappings=/simulator/rest/**
 
 citrus.simulator.ws.enabled=true
-citrus.simulator.ws.servlet-mapping=/simulator/ws/**
+citrus.simulator.ws.servlet-mappings=/simulator/ws/*


### PR DESCRIPTION
- [x] to be merged after https://github.com/citrusframework/citrus-simulator/pull/226.

the property `citrus.simulator.ws.servlet-mapping` is
now `citrus.simulator.ws.servlet-mappings`, which is a list of strings.
the default value still is `/services/ws/*`, but you can define multiple
endpoints and still be compliant with the servlet specification.