### PR TITLE
sortable scenario executions

### DIFF
--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.spec.ts
@@ -1,13 +1,16 @@
+import { EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
 import { of } from 'rxjs';
 
 import { ScenarioExecutionService } from '../service/scenario-execution.service';
 
 import { ScenarioExecutionComponent } from './scenario-execution.component';
+
 import SpyInstance = jest.SpyInstance;
 
 describe('ScenarioExecution Management Component', () => {
@@ -62,13 +65,31 @@ describe('ScenarioExecution Management Component', () => {
     );
   });
 
-  it('should call load all on init', () => {
-    // WHEN
-    comp.ngOnInit();
+  describe('ngOnInit', () => {
+    it('should call load all on init', () => {
+      // WHEN
+      comp.ngOnInit();
 
-    // THEN
-    expect(service.query).toHaveBeenCalled();
-    expect(comp.scenarioExecutions?.[0]).toEqual(expect.objectContaining({ executionId: 123 }));
+      // THEN
+      expect(service.query).toHaveBeenCalled();
+      expect(comp.scenarioExecutions?.[0]).toEqual(expect.objectContaining({ executionId: 123 }));
+    });
+
+    it('should calculate the filter attribute', () => {
+      // WHEN
+      comp.ngOnInit();
+
+      // THEN
+      expect(service.query).toHaveBeenLastCalledWith(expect.objectContaining({ 'someId.in': ['dc4279ea-cfb9-11ec-9d64-0242ac120002'] }));
+    });
+
+    it('should calculate the sort attribute for an id', () => {
+      // WHEN
+      comp.ngOnInit();
+
+      // THEN
+      expect(service.query).toHaveBeenLastCalledWith(expect.objectContaining({ sort: ['executionId,desc'] }));
+    });
   });
 
   describe('trackId', () => {
@@ -81,45 +102,36 @@ describe('ScenarioExecution Management Component', () => {
     });
   });
 
-  it('should load a page', () => {
-    // WHEN
-    comp.navigateToPage(1);
+  describe('navigateToPage', () => {
+    it('should load a page', () => {
+      // WHEN
+      comp.navigateToPage(1);
 
-    // THEN
-    expect(routerNavigateSpy).toHaveBeenCalled();
+      // THEN
+      expect(routerNavigateSpy).toHaveBeenCalled();
+    });
   });
 
-  it('should calculate the sort attribute for an id', () => {
-    // WHEN
-    comp.ngOnInit();
+  describe('navigateToWithComponentValues', () => {
+    it('should calculate the sort attribute for a non-id attribute', () => {
+      // GIVEN
+      const predicate = 'name';
+      comp.predicate = predicate;
+      comp.sortChange = { emit: jest.fn() } as unknown as EventEmitter<any>;
 
-    // THEN
-    expect(service.query).toHaveBeenLastCalledWith(expect.objectContaining({ sort: ['executionId,desc'] }));
-  });
+      // WHEN
+      comp.navigateToWithComponentValues();
 
-  it('should calculate the sort attribute for a non-id attribute', () => {
-    // GIVEN
-    comp.predicate = 'name';
-
-    // WHEN
-    comp.navigateToWithComponentValues();
-
-    // THEN
-    expect(routerNavigateSpy).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        queryParams: expect.objectContaining({
-          sort: ['name,asc'],
+      // THEN
+      expect(comp.sortChange.emit).toHaveBeenCalledWith({ predicate, ascending: true });
+      expect(routerNavigateSpy).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          queryParams: expect.objectContaining({
+            sort: ['name,asc'],
+          }),
         }),
-      }),
-    );
-  });
-
-  it('should calculate the filter attribute', () => {
-    // WHEN
-    comp.ngOnInit();
-
-    // THEN
-    expect(service.query).toHaveBeenLastCalledWith(expect.objectContaining({ 'someId.in': ['dc4279ea-cfb9-11ec-9d64-0242ac120002'] }));
+      );
+    });
   });
 });

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.ts
@@ -1,18 +1,19 @@
-import { Component, Input, NgZone, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, NgZone, OnInit, Output } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router, RouterModule } from '@angular/router';
+
 import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
+import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
+
+import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
+import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
 import SharedModule from 'app/shared/shared.module';
 import { SortDirective, SortByDirective } from 'app/shared/sort';
 import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 import { ItemCountComponent } from 'app/shared/pagination';
-import { FormsModule } from '@angular/forms';
-
-import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
-import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
-import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
-import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
 
 import { EntityArrayResponseType, ScenarioExecutionService } from '../service/scenario-execution.service';
 import { IScenarioExecution, IScenarioExecutionStatus } from '../scenario-execution.model';
@@ -37,6 +38,8 @@ import { IScenarioExecution, IScenarioExecutionStatus } from '../scenario-execut
 export class ScenarioExecutionComponent implements OnInit {
   @Input() hideTitle = false;
 
+  @Output() sortChange = new EventEmitter<{ predicate: string; ascending: boolean }>();
+
   scenarioExecutions?: IScenarioExecution[];
   isLoading = false;
 
@@ -48,6 +51,8 @@ export class ScenarioExecutionComponent implements OnInit {
   itemsPerPage = ITEMS_PER_PAGE;
   totalItems = 0;
   page = 1;
+
+  protected readonly USER_PREFERENCES_KEY = 'scenario';
 
   private filters: IFilterOptions = new FilterOptions();
 
@@ -75,6 +80,7 @@ export class ScenarioExecutionComponent implements OnInit {
   }
 
   navigateToWithComponentValues(): void {
+    this.sortChange.emit({ predicate: this.predicate, ascending: this.ascending });
     this.handleNavigation(this.page, this.predicate, this.ascending, this.filters.filterOptions);
   }
 

--- a/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.html
+++ b/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.html
@@ -5,7 +5,7 @@
     <div *ngIf="scenarioExecutionComponent" class="d-flex justify-content-end">
       <app-select-page-size
         class="col-md-4 me-3"
-        [key]="itemsPerPageKey"
+        [key]="USER_PREFERENCES_KEY"
         (pageSizeChanged)="pageSizeChanged($event)"
       ></app-select-page-size>
       <button class="btn btn-info me-2" (click)="scenarioExecutionComponent!.load()" [disabled]="scenarioExecutionComponent!.isLoading">
@@ -19,5 +19,5 @@
     <app-scenario-execution-filter></app-scenario-execution-filter>
   </div>
 
-  <app-scenario-execution [hideTitle]="true"></app-scenario-execution>
+  <app-scenario-execution [hideTitle]="true" (sortChange)="updateUserPreferences($event)"></app-scenario-execution>
 </div>

--- a/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.spec.ts
@@ -4,8 +4,10 @@ import { UserPreferenceService } from 'app/core/config/user-preference.service';
 import { ScenarioExecutionComponent } from 'app/entities/scenario-execution/list/scenario-execution.component';
 
 import ScenarioResultComponent from './scenario-result.component';
+import { EntityOrder } from '../config/navigation.constants';
+import { ChangeDetectorRef } from '@angular/core';
 
-type SpyInstance = jest.SpyInstance;
+import SpyInstance = jest.SpyInstance;
 
 const itemsPerPage = 1234;
 
@@ -24,6 +26,10 @@ describe('ScenarioResult Component', () => {
           provide: UserPreferenceService,
           useValue: {
             getPageSize: jest.fn(),
+            getPredicate: jest.fn(),
+            setPredicate: jest.fn(),
+            getEntityOrder: jest.fn(),
+            setEntityOrder: jest.fn(),
           },
         },
       ],
@@ -33,6 +39,7 @@ describe('ScenarioResult Component', () => {
 
     scenarioExecutionComponent = {
       itemsPerPage: 0,
+      navigateToWithComponentValues: jest.fn(),
       load: jest.fn(),
     } as unknown as ScenarioExecutionComponent;
 
@@ -43,21 +50,39 @@ describe('ScenarioResult Component', () => {
   });
 
   describe('ngAfterViewInit', () => {
-    it('initially loads page size', () => {
-      (userPreferenceService.getPageSize as unknown as SpyInstance).mockReturnValueOnce(itemsPerPage);
-      component.scenarioExecutionComponent = scenarioExecutionComponent;
+    let detectChangesSpy: SpyInstance<any>;
 
-      component.ngAfterViewInit();
-
-      expect(scenarioExecutionComponent.itemsPerPage).toEqual(itemsPerPage);
-      expect(scenarioExecutionComponent.load).toHaveBeenCalled();
+    beforeEach(() => {
+      const changeDetectorRef = fixture.debugElement.injector.get(ChangeDetectorRef);
+      detectChangesSpy = jest.spyOn(changeDetectorRef.constructor.prototype, 'detectChanges');
     });
+
+    test.each([{ entityOrder: EntityOrder.ASCENDING }, { entityOrder: EntityOrder.DESCENDING }])(
+      'initially loads page size',
+      ({ entityOrder }) => {
+        (userPreferenceService.getPageSize as unknown as SpyInstance).mockReturnValueOnce(itemsPerPage);
+        (userPreferenceService.getPredicate as unknown as SpyInstance).mockReturnValueOnce(itemsPerPage);
+        (userPreferenceService.getEntityOrder as unknown as SpyInstance).mockReturnValueOnce(entityOrder);
+        component.scenarioExecutionComponent = scenarioExecutionComponent;
+
+        component.ngAfterViewInit();
+
+        expect(scenarioExecutionComponent.itemsPerPage).toEqual(itemsPerPage);
+        expect(scenarioExecutionComponent.predicate).toEqual(itemsPerPage);
+        expect(scenarioExecutionComponent.ascending).toEqual(entityOrder === EntityOrder.ASCENDING);
+
+        expect(scenarioExecutionComponent.navigateToWithComponentValues).toHaveBeenCalled();
+
+        expect(detectChangesSpy).toHaveBeenCalled();
+      },
+    );
   });
 
   describe('pageSizeChanged', () => {
     it('reloads the component if it exists', () => {
       component.scenarioExecutionComponent = scenarioExecutionComponent;
 
+      // @ts-ignore: Access private function for testing
       component.pageSizeChanged(itemsPerPage);
 
       expect(scenarioExecutionComponent.itemsPerPage).toEqual(itemsPerPage);
@@ -65,8 +90,23 @@ describe('ScenarioResult Component', () => {
     });
 
     it('does nothing if component does not exist', () => {
+      // @ts-ignore: Access private function for testing
       component.pageSizeChanged(itemsPerPage);
       expect(scenarioExecutionComponent.itemsPerPage).toEqual(0);
+      expect(scenarioExecutionComponent.load).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserPreferences', () => {
+    test.each([
+      { predicate: 'predicate', ascending: true, expectedEntityOrder: EntityOrder.ASCENDING },
+      { predicate: 'predicate', ascending: false, expectedEntityOrder: EntityOrder.DESCENDING },
+    ])('persists the values into the user service', ({ predicate, ascending, expectedEntityOrder }) => {
+      // @ts-ignore: Access private function for testing
+      component.updateUserPreferences({ predicate, ascending });
+
+      expect(userPreferenceService.setPredicate).toHaveBeenCalledWith('scenario-result', predicate);
+      expect(userPreferenceService.setEntityOrder).toHaveBeenCalledWith('scenario-result', expectedEntityOrder);
     });
   });
 });

--- a/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.html
+++ b/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.html
@@ -26,7 +26,7 @@
   <div class="table-responsive table-entities" id="entities" *ngIf="scenarios && scenarios.length > 0">
     <table class="table table-striped" aria-describedby="page-heading">
       <thead>
-        <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="navigateToWithComponentValues()">
+        <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="navigateToWithComponentValues($event)">
           <th scope="col" jhiSortBy="name">
             <div class="d-flex">
               <span jhiTranslate="citrusSimulatorApp.scenario.name">Name</span>

--- a/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.ts
+++ b/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.ts
@@ -71,7 +71,7 @@ export class ScenarioComponent implements OnInit {
     this.entityOrder = this.userPreferenceService.getEntityOrder(this.USER_PREFERENCES_KEY);
     this.ascending = this.entityOrder === EntityOrder.ASCENDING;
 
-    this.navigateToWithComponentValues();
+    this.navigateToWithComponentValues({ predicate: this.predicate, ascending: this.ascending });
     this.load();
     this.changeDetectorRef.detectChanges();
   }
@@ -84,8 +84,9 @@ export class ScenarioComponent implements OnInit {
     });
   }
 
-  navigateToWithComponentValues(): void {
-    this.handleNavigation(this.page, this.predicate, this.ascending);
+  navigateToWithComponentValues({ predicate, ascending }: { predicate: string; ascending: boolean }): void {
+    this.updateUserPreferences(predicate, ascending);
+    this.handleNavigation(this.page, predicate, ascending);
   }
 
   navigateToPage(page = this.page): void {
@@ -103,12 +104,8 @@ export class ScenarioComponent implements OnInit {
     const page = params.get(PAGE_HEADER);
     this.page = +(page ?? 1);
     const sort = (params.get(SORT) ?? data[DEFAULT_SORT_DATA]).split(',');
-
     this.predicate = sort[0];
-    this.userPreferenceService.setPredicate(this.USER_PREFERENCES_KEY, this.predicate);
-
     this.entityOrder = toEntityOrder(sort[1]) ?? EntityOrder.ASCENDING;
-    this.userPreferenceService.setEntityOrder(this.USER_PREFERENCES_KEY, this.entityOrder);
     this.ascending = this.entityOrder === EntityOrder.ASCENDING;
   }
 
@@ -192,5 +189,10 @@ export class ScenarioComponent implements OnInit {
   protected pageSizeChanged(itemsPerPage: number): void {
     this.itemsPerPage = itemsPerPage;
     this.load();
+  }
+
+  private updateUserPreferences(predicate: string, ascending: boolean): void {
+    this.userPreferenceService.setPredicate(this.USER_PREFERENCES_KEY, predicate);
+    this.userPreferenceService.setEntityOrder(this.USER_PREFERENCES_KEY, ascending ? EntityOrder.ASCENDING : EntityOrder.DESCENDING);
   }
 }


### PR DESCRIPTION
>  Default Sorting of Executions: The default display seems to list the oldest Executions at the top. It would be more user-friendly to have an option to customize this default sorting to suit individual preferences.