### PR TITLE
simulator UI infinity loop fix

### DIFF
--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/MessageQueryService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/MessageQueryService.java
@@ -16,11 +16,8 @@
 
 package org.citrusframework.simulator.service;
 
-import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.JoinType;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.citrusframework.simulator.model.Message;
 import org.citrusframework.simulator.model.MessageHeader_;
@@ -34,6 +31,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
+import static org.springframework.data.domain.Pageable.unpaged;
 
 /**
  * Service for executing complex queries for {@link Message} entities in the database.
@@ -74,7 +76,7 @@ public class MessageQueryService extends QueryService<Message> {
         )
             .getResultList();
 
-        var messages = messageRepository.findAllWhereIdIn(messageIds, page);
+        var messages = messageRepository.findAllWhereIdIn(messageIds, unpaged(page.getSort()));
         return new PageImpl<>(messages.getContent(), page, messageRepository.count(specification));
     }
 

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionQueryService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionQueryService.java
@@ -16,11 +16,8 @@
 
 package org.citrusframework.simulator.service;
 
-import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.JoinType;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.citrusframework.simulator.model.Message_;
 import org.citrusframework.simulator.model.ScenarioAction_;
@@ -35,6 +32,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
+import static org.springframework.data.domain.Pageable.unpaged;
 
 /**
  * Service for executing complex queries for {@link ScenarioExecution} entities in the database.
@@ -89,7 +91,7 @@ public class ScenarioExecutionQueryService extends QueryService<ScenarioExecutio
         )
             .getResultList();
 
-        var scenarioExecutions = scenarioExecutionRepository.findAllWhereIdIn(scenarioExecutionIds, page);
+        var scenarioExecutions = scenarioExecutionRepository.findAllWhereIdIn(scenarioExecutionIds, unpaged(page.getSort()));
         return new PageImpl<>(scenarioExecutions.getContent(), page, scenarioExecutionRepository.count(specification));
     }
 

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/TestResultQueryService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/TestResultQueryService.java
@@ -16,11 +16,8 @@
 
 package org.citrusframework.simulator.service;
 
-import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.JoinType;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.citrusframework.simulator.model.TestParameter_;
 import org.citrusframework.simulator.model.TestResult;
@@ -33,6 +30,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.citrusframework.simulator.service.CriteriaQueryUtils.newSelectIdBySpecificationQuery;
+import static org.springframework.data.domain.Pageable.unpaged;
 
 /**
  * Service for executing complex queries for {@link TestResult} entities in the database.
@@ -73,7 +75,7 @@ public class TestResultQueryService extends QueryService<TestResult> {
         )
             .getResultList();
 
-        var testResults = testResultRepository.findAllWhereIdIn(testResultIds, page);
+        var testResults = testResultRepository.findAllWhereIdIn(testResultIds, unpaged(page.getSort()));
         return new PageImpl<>(testResults.getContent(), page, testResultRepository.count(specification));
     }
 

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/MessageQueryServiceIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/MessageQueryServiceIT.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import org.citrusframework.simulator.IntegrationTest;
 import org.citrusframework.simulator.model.Message;
 import org.citrusframework.simulator.model.Message_;
+import org.citrusframework.simulator.model.TestResult_;
 import org.citrusframework.simulator.repository.MessageRepository;
 import org.citrusframework.simulator.service.criteria.MessageCriteria;
 import org.citrusframework.simulator.service.filter.LongFilter;
@@ -128,6 +129,18 @@ class MessageQueryServiceIT {
             assertThat(messagePage.getTotalPages()).isEqualTo(expectedTotalPages);
             assertThat(messagePage.getTotalElements()).isEqualTo(3L);
             assertThat(messagePage.getContent()).hasSize(pageSize);
+        }
+
+        @Test
+        void selectSecondPage() {
+            Page<Message> testResultPage = fixture.findByCriteria(
+                new MessageCriteria(),
+                PageRequest.of(1, 1, Sort.by(ASC, TestResult_.ID))
+            );
+
+            assertThat(testResultPage.getTotalPages()).isEqualTo(3);
+            assertThat(testResultPage.getTotalElements()).isEqualTo(3L);
+            assertThat(testResultPage.getContent()).hasSize(1).first().isEqualTo(messages.get(1));
         }
 
         static Stream<Arguments> testSinglePropertySort() {

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/ScenarioExecutionQueryServiceIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/ScenarioExecutionQueryServiceIT.java
@@ -7,6 +7,7 @@ import org.citrusframework.simulator.model.ScenarioAction;
 import org.citrusframework.simulator.model.ScenarioExecution;
 import org.citrusframework.simulator.model.ScenarioExecution_;
 import org.citrusframework.simulator.model.ScenarioParameter;
+import org.citrusframework.simulator.model.TestResult_;
 import org.citrusframework.simulator.repository.ScenarioExecutionRepository;
 import org.citrusframework.simulator.service.criteria.ScenarioExecutionCriteria;
 import org.citrusframework.simulator.service.filter.LongFilter;
@@ -195,6 +196,18 @@ class ScenarioExecutionQueryServiceIT {
             assertThat(scenarioExecutionPage.getTotalPages()).isEqualTo(expectedTotalPages);
             assertThat(scenarioExecutionPage.getTotalElements()).isEqualTo(3L);
             assertThat(scenarioExecutionPage.getContent()).hasSize(pageSize);
+        }
+
+        @Test
+        void selectSecondPage() {
+            Page<ScenarioExecution> testResultPage = fixture.findByCriteria(
+                new ScenarioExecutionCriteria(),
+                PageRequest.of(1, 1, Sort.by(ASC, TestResult_.ID))
+            );
+
+            assertThat(testResultPage.getTotalPages()).isEqualTo(3);
+            assertThat(testResultPage.getTotalElements()).isEqualTo(3L);
+            assertThat(testResultPage.getContent()).hasSize(1).first().isEqualTo(scenarioExecutions.get(1));
         }
 
         static Stream<Arguments> testSinglePropertySort() {

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/TestResultQueryServiceIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/TestResultQueryServiceIT.java
@@ -161,6 +161,18 @@ class TestResultQueryServiceIT {
             assertThat(testResultPage.getContent()).hasSize(pageSize);
         }
 
+        @Test
+        void selectSecondPage() {
+            Page<TestResult> testResultPage = fixture.findByCriteria(
+                new TestResultCriteria(),
+                PageRequest.of(1, 1, Sort.by(ASC, TestResult_.ID))
+            );
+
+            assertThat(testResultPage.getTotalPages()).isEqualTo(3);
+            assertThat(testResultPage.getTotalElements()).isEqualTo(3L);
+            assertThat(testResultPage.getContent()).hasSize(1).first().isEqualTo(testResults.get(1));
+        }
+
         static Stream<Arguments> testSinglePropertySort() {
             return Stream.of(
                 arguments(

--- a/simulator-ui/src/main/webapp/app/entities/message-header/list/message-header.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/message-header/list/message-header.component.ts
@@ -1,5 +1,5 @@
 import { HttpHeaders } from '@angular/common/http';
-import { Component, Input, NgZone, OnInit } from '@angular/core';
+import { Component, NgZone, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router } from '@angular/router';
 
@@ -19,6 +19,8 @@ import { EntityArrayResponseType, MessageHeaderService } from '../service/messag
 import { IMessageHeader } from '../message-header.model';
 
 import MessageHeaderTableComponent from './message-header-table.component';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -125,21 +127,16 @@ export class MessageHeaderComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/entities/message/list/message.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/message/list/message.component.ts
@@ -1,21 +1,24 @@
 import { Component, NgZone, OnInit } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router, RouterModule } from '@angular/router';
+
 import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
-import SharedModule from 'app/shared/shared.module';
-import { SortDirective, SortByDirective } from 'app/shared/sort';
-import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
-import { ItemCountComponent } from 'app/shared/pagination';
-import { FormsModule } from '@angular/forms';
-
-import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
+import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
+import { ItemCountComponent } from 'app/shared/pagination';
+import { SortDirective, SortByDirective } from 'app/shared/sort';
 
 import { EntityArrayResponseType, MessageService } from '../service/message.service';
 import { IMessage } from '../message.model';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -132,21 +135,16 @@ export class MessageComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/entities/navigation-util.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/navigation-util.spec.ts
@@ -1,0 +1,85 @@
+import { NgZone } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { IFilterOption } from '../shared/filter';
+
+import { navigateToWithPagingInformation } from './navigation-util';
+
+describe('navigation-util', () => {
+  describe('navigateToWithPagingInformation', () => {
+    let ngZone: NgZone;
+    let router: Router;
+    let activatedRoute: ActivatedRoute;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule.withRoutes([])],
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: { queryParams: {} },
+            },
+          },
+        ],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      ngZone = { run: (invocation: any) => invocation() } as unknown as NgZone;
+      jest.spyOn(ngZone, 'run');
+      router = TestBed.inject(Router);
+      jest.spyOn(router, 'navigate');
+      activatedRoute = TestBed.inject(ActivatedRoute);
+    });
+
+    it('should navigate with page and itemsPerPage', () => {
+      const page = 2;
+      const itemsPerPage = 10;
+
+      navigateToWithPagingInformation(page, itemsPerPage, () => [], ngZone, router, activatedRoute);
+
+      expect(ngZone.run).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['./'], {
+        relativeTo: activatedRoute,
+        queryParams: { page, size: itemsPerPage, sort: [] },
+      });
+    });
+
+    it('should navigate with sort parameters', () => {
+      const page = 1;
+      const itemsPerPage = 25;
+      const predicate = 'name';
+      const ascending = true;
+      const getSortQueryParam = jest.fn().mockReturnValueOnce(['name,asc']);
+
+      navigateToWithPagingInformation(page, itemsPerPage, getSortQueryParam, ngZone, router, activatedRoute, predicate, ascending);
+
+      expect(ngZone.run).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['./'], {
+        relativeTo: activatedRoute,
+        queryParams: { page, size: itemsPerPage, sort: ['name,asc'] },
+      });
+    });
+
+    it('should navigate with filter options', () => {
+      const page = 3;
+      const itemsPerPage = 50;
+
+      const categoryQueryParam = 'catecurry';
+      const filterOptions: IFilterOption[] = [
+        { name: 'category', values: ['electronics'], nameAsQueryParam: () => categoryQueryParam },
+        { name: 'price', values: ['100-200'], nameAsQueryParam: () => 'price' },
+      ];
+
+      navigateToWithPagingInformation(page, itemsPerPage, () => [], ngZone, router, activatedRoute, undefined, undefined, filterOptions);
+
+      expect(ngZone.run).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['./'], {
+        relativeTo: activatedRoute,
+        queryParams: { page, size: itemsPerPage, sort: [], [categoryQueryParam]: ['electronics'], price: ['100-200'] },
+      });
+    });
+  });
+});

--- a/simulator-ui/src/main/webapp/app/entities/navigation-util.ts
+++ b/simulator-ui/src/main/webapp/app/entities/navigation-util.ts
@@ -1,0 +1,34 @@
+import { IFilterOption } from '../shared/filter';
+import { NgZone } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+export const navigateToWithPagingInformation = (
+  page: number,
+  itemsPerPage: number,
+  getSortQueryParam: (predicate?: string, ascending?: boolean) => string[],
+  ngZone: NgZone,
+  router: Router,
+  activatedRoute: ActivatedRoute,
+  predicate?: string,
+  ascending?: boolean,
+  filterOptions?: IFilterOption[],
+): void => {
+  const queryParamsObj: any = {
+    page,
+    size: itemsPerPage,
+    sort: getSortQueryParam(predicate, ascending),
+  };
+
+  filterOptions?.forEach(filterOption => {
+    queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
+  });
+
+  ngZone
+    .run(() =>
+      router.navigate(['./'], {
+        relativeTo: activatedRoute,
+        queryParams: queryParamsObj,
+      }),
+    )
+    .catch(() => location.reload());
+};

--- a/simulator-ui/src/main/webapp/app/entities/scenario-action/list/scenario-action.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-action/list/scenario-action.component.ts
@@ -1,20 +1,24 @@
 import { Component, NgZone, OnInit } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router, RouterModule } from '@angular/router';
+
 import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
-import SharedModule from 'app/shared/shared.module';
-import { SortDirective, SortByDirective } from 'app/shared/sort';
-import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
-import { ItemCountComponent } from 'app/shared/pagination';
-import { FormsModule } from '@angular/forms';
-
-import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
+import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
+import { ItemCountComponent } from 'app/shared/pagination';
+import { SortDirective, SortByDirective } from 'app/shared/sort';
+
 import { EntityArrayResponseType, ScenarioActionService } from '../service/scenario-action.service';
 import { IScenarioAction } from '../scenario-action.model';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -131,21 +135,16 @@ export class ScenarioActionComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/entities/scenario-parameter/list/scenario-parameter.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-parameter/list/scenario-parameter.component.ts
@@ -1,21 +1,24 @@
 import { Component, NgZone, OnInit } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router, RouterModule } from '@angular/router';
+
 import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
-import SharedModule from 'app/shared/shared.module';
-import { SortDirective, SortByDirective } from 'app/shared/sort';
-import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
-import { ItemCountComponent } from 'app/shared/pagination';
-import { FormsModule } from '@angular/forms';
-
-import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
+import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
+import { ItemCountComponent } from 'app/shared/pagination';
+import { SortDirective, SortByDirective } from 'app/shared/sort';
 
 import { EntityArrayResponseType, ScenarioParameterService } from '../service/scenario-parameter.service';
 import { IScenarioParameter } from '../scenario-parameter.model';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -132,21 +135,16 @@ export class ScenarioParameterComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/entities/test-parameter/list/test-parameter.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/test-parameter/list/test-parameter.component.ts
@@ -1,21 +1,24 @@
 import { Component, NgZone, OnInit } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Data, ParamMap, Router, RouterModule } from '@angular/router';
+
 import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
-import SharedModule from 'app/shared/shared.module';
-import { SortDirective, SortByDirective } from 'app/shared/sort';
-import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
-import { ItemCountComponent } from 'app/shared/pagination';
-import { FormsModule } from '@angular/forms';
-
-import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
+import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
+import { ItemCountComponent } from 'app/shared/pagination';
+import { SortDirective, SortByDirective } from 'app/shared/sort';
 
 import { EntityArrayResponseType, TestParameterService } from '../service/test-parameter.service';
 import { ITestParameter } from '../test-parameter.model';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -131,21 +134,16 @@ export class TestParameterComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/entities/test-result/list/test-result.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/test-result/list/test-result.component.ts
@@ -7,15 +7,18 @@ import { combineLatest, Observable, switchMap, tap } from 'rxjs';
 
 import { ASC, DESC, SORT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
 import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
+
 import SharedModule from 'app/shared/shared.module';
-import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
+import { formatDateTimeFilterOptions } from 'app/shared/date/format-date-time-filter-options';
 import { FilterComponent, FilterOptions, IFilterOptions, IFilterOption } from 'app/shared/filter';
 import { ItemCountComponent } from 'app/shared/pagination';
 import { SortDirective, SortByDirective } from 'app/shared/sort';
 
 import { EntityArrayResponseType, TestResultService } from '../service/test-result.service';
 import { ITestResult, ITestResultStatus } from '../test-result.model';
+
+import { navigateToWithPagingInformation } from '../../navigation-util';
 
 @Component({
   standalone: true,
@@ -131,21 +134,16 @@ export class TestResultComponent implements OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 

--- a/simulator-ui/src/main/webapp/app/scenario-result/scenario-execution-filter.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/scenario-result/scenario-execution-filter.component.spec.ts
@@ -31,7 +31,7 @@ describe('ScenarioExecution Filter Component', () => {
         },
         {
           provide: ActivatedRoute,
-          useValue: { queryParamMap: of(convertToParamMap({})) },
+          useValue: { queryParamMap: of(convertToParamMap({})), queryParams: of({}) },
         },
       ],
     })
@@ -54,7 +54,7 @@ describe('ScenarioExecution Filter Component', () => {
         convertToParamMap({
           'filter[scenarioName.contains]': nameContains,
           'filter[startDate.greaterThanOrEqual]': queryParamStartDate,
-          'filter[status.in]': STATUS_SUCCESS.id,
+          'filter[status.equals]': STATUS_SUCCESS.id,
           'filter[endDate.lessThanOrEqual]': queryParamEndDate,
         }),
       );
@@ -110,7 +110,7 @@ describe('ScenarioExecution Filter Component', () => {
         queryParams: {
           'filter[scenarioName.contains]': nameContains,
           'filter[startDate.greaterThanOrEqual]': queryParamStartDate,
-          'filter[status.in]': STATUS_SUCCESS.id,
+          'filter[status.equals]': STATUS_SUCCESS.id,
           'filter[endDate.lessThanOrEqual]': queryParamEndDate,
         },
       });
@@ -134,6 +134,7 @@ describe('ScenarioExecution Filter Component', () => {
       expect(filterFormValueChanges.unsubscribe).toHaveBeenCalled();
     });
   });
+
   describe('applyFilter', () => {
     it('should navigate with correct query parameters', () => {
       const nameContains = 'nameContains';
@@ -152,9 +153,52 @@ describe('ScenarioExecution Filter Component', () => {
         queryParams: {
           'filter[scenarioName.contains]': nameContains,
           'filter[startDate.greaterThanOrEqual]': queryParamStartDate,
-          'filter[status.in]': STATUS_SUCCESS.id,
+          'filter[status.equals]': STATUS_SUCCESS.id,
           'filter[endDate.lessThanOrEqual]': queryParamEndDate,
         },
+      });
+    });
+
+    it('should ignore undefined parameters', () => {
+      component.filterForm.controls['statusIn'].setValue(STATUS_SUCCESS.name);
+
+      // @ts-ignore: Access protected function for testing
+      component.applyFilter();
+
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: {
+          'filter[status.equals]': STATUS_SUCCESS.id,
+        },
+      });
+    });
+
+    it('should merge with existing query params', () => {
+      const existing = 'some-value';
+      activatedRoute.queryParams = of({ existing });
+
+      component.filterForm.controls['statusIn'].setValue(STATUS_SUCCESS.name);
+
+      // @ts-ignore: Access protected function for testing
+      component.applyFilter();
+
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: {
+          existing,
+          'filter[status.equals]': STATUS_SUCCESS.id,
+        },
+      });
+    });
+
+    it('undefined parameters override existing query params', () => {
+      activatedRoute.queryParams = of({ 'filter[scenarioName.contains]': 'drama queen' });
+
+      component.filterForm.controls['statusIn'].setValue(undefined);
+
+      // @ts-ignore: Access protected function for testing
+      component.applyFilter();
+
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: {},
       });
     });
   });

--- a/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.spec.ts
@@ -93,7 +93,7 @@ describe('ScenarioResult Component', () => {
       component.pageSizeChanged(itemsPerPage);
 
       expect(scenarioExecutionComponent.itemsPerPage).toEqual(itemsPerPage);
-      expect(scenarioExecutionComponent.load).toHaveBeenCalled();
+      expect(scenarioExecutionComponent.navigateToWithComponentValues).toHaveBeenCalled();
     });
 
     it('does nothing if component does not exist', () => {

--- a/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.ts
+++ b/simulator-ui/src/main/webapp/app/scenario-result/scenario-result.component.ts
@@ -46,7 +46,7 @@ export default class ScenarioResultComponent implements AfterViewInit {
   protected pageSizeChanged(pageSize: number): void {
     if (this.scenarioExecutionComponent) {
       this.scenarioExecutionComponent.itemsPerPage = pageSize;
-      this.scenarioExecutionComponent.load();
+      this.scenarioExecutionComponent.navigateToWithComponentValues();
     }
   }
 

--- a/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.ts
+++ b/simulator-ui/src/main/webapp/app/scenario/list/scenario.component.ts
@@ -11,16 +11,18 @@ import { ASC, DEFAULT_SORT_DATA, DESC, EntityOrder, SORT, toEntityOrder } from '
 import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 
 import { UserPreferenceService } from 'app/core/config/user-preference.service';
-
-import { DurationPipe, FormatMediumDatePipe, FormatMediumDatetimePipe } from 'app/shared/date';
 import { AlertService } from 'app/core/util/alert.service';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatePipe, FormatMediumDatetimePipe } from 'app/shared/date';
 import { FilterComponent, IFilterOption } from 'app/shared/filter';
 import { ItemCountComponent } from 'app/shared/pagination';
-import SharedModule from 'app/shared/shared.module';
 import { SortByDirective, SortDirective } from 'app/shared/sort';
 
 import { EntityArrayResponseType, ScenarioService } from '../service/scenario.service';
 import { IScenario } from '../scenario.model';
+
+import { navigateToWithPagingInformation } from '../../entities/navigation-util';
 
 type ScenarioFilter = {
   nameContains: string | undefined;
@@ -176,21 +178,16 @@ export class ScenarioComponent implements OnDestroy, OnInit {
   }
 
   protected handleNavigation(page = this.page, predicate?: string, ascending?: boolean, filterOptions?: IFilterOption[]): void {
-    const queryParamsObj: any = {
+    navigateToWithPagingInformation(
       page,
-      size: this.itemsPerPage,
-      sort: this.getSortQueryParam(predicate, ascending),
-    };
-
-    filterOptions?.forEach(filterOption => {
-      queryParamsObj[filterOption.nameAsQueryParam()] = filterOption.values;
-    });
-
-    this.ngZone.run(() =>
-      this.router.navigate(['./'], {
-        relativeTo: this.activatedRoute,
-        queryParams: queryParamsObj,
-      }),
+      this.itemsPerPage,
+      () => this.getSortQueryParam(predicate, ascending),
+      this.ngZone,
+      this.router,
+      this.activatedRoute,
+      predicate,
+      ascending,
+      filterOptions,
     );
   }
 


### PR DESCRIPTION
merge query params with existing ones, so page does not flick back to old params when navigating with filters.

also found a bug in the backend while clicking throught the UI. the whole pagination object was passed to the subsequent query, instead of only the sorting parameter.

closes #258.