### PR TITLE
scenario details

### DIFF
--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.html
@@ -1,0 +1,59 @@
+<div class="table-responsive table-entities" id="entities" *ngIf="sortedActions && sortedActions.length > 0; else noParameters">
+  <table class="table table-striped" aria-describedby="page-heading">
+    <thead>
+      <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="sortActions()">
+        <th scope="col" jhiSortBy="actionId">
+          <div class="d-flex">
+            <span jhiTranslate="global.field.id">ID</span>
+            <fa-icon class="p-1" icon="sort"></fa-icon>
+          </div>
+        </th>
+        <th scope="col" jhiSortBy="name">
+          <div class="d-flex">
+            <span jhiTranslate="citrusSimulatorApp.scenarioAction.name">Name</span>
+            <fa-icon class="p-1" icon="sort"></fa-icon>
+          </div>
+        </th>
+        <th scope="col" jhiSortBy="startDate">
+          <div class="d-flex">
+            <span jhiTranslate="citrusSimulatorApp.scenarioAction.startDate">Start Date</span>
+            <fa-icon class="p-1" icon="sort"></fa-icon>
+          </div>
+        </th>
+        <th scope="col" jhiSortBy="endDate">
+          <div class="d-flex">
+            <span jhiTranslate="citrusSimulatorApp.scenarioAction.endDate">End Date</span>
+            <fa-icon class="p-1" icon="sort"></fa-icon>
+          </div>
+        </th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let scenarioAction of sortedActions; trackBy: trackId" data-cy="entityTable">
+        <td>
+          <a [routerLink]="['/scenario-action', scenarioAction.actionId, 'view']">{{ scenarioAction.actionId }}</a>
+        </td>
+        <td>{{ scenarioAction.name }}</td>
+        <td>{{ scenarioAction.startDate | formatMediumDatetime }}</td>
+        <td>{{ scenarioAction.endDate | formatMediumDatetime }}</td>
+        <td class="text-end">
+          <div class="btn-group">
+            <a [routerLink]="['/scenario-action', scenarioAction.actionId, 'view']">
+              <button type="submit" class="btn btn-info btn-sm" data-cy="entityDetailsButton">
+                <fa-icon icon="eye"></fa-icon>
+                <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+              </button>
+            </a>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<ng-template #noParameters>
+  <div class="alert alert-warning" id="no-result">
+    <span jhiTranslate="citrusSimulatorApp.scenarioAction.home.notFound">No Scenario Actions found</span>
+  </div>
+</ng-template>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.spec.ts
@@ -1,0 +1,67 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import * as operators from 'app/core/util/operators';
+
+import { IScenarioAction } from 'app/entities/scenario-action/scenario-action.model';
+
+import { ScenarioActionsTableComponent } from './scenario-actions-table.component';
+
+import SpyInstance = jest.SpyInstance;
+
+describe('Message Table Component', () => {
+  let sortSpy: SpyInstance;
+
+  let fixture: ComponentFixture<ScenarioActionsTableComponent>;
+  let component: ScenarioActionsTableComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes([{ path: 'message', component: ScenarioActionsTableComponent }]),
+        HttpClientTestingModule,
+        ScenarioActionsTableComponent,
+      ],
+      providers: [],
+    })
+      .overrideTemplate(ScenarioActionsTableComponent, '')
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ScenarioActionsTableComponent);
+    component = fixture.componentInstance;
+
+    sortSpy = jest.spyOn(operators, 'sort');
+    sortSpy.mockClear();
+  });
+
+  describe('ngOnInit', () => {
+    it('sorts actions', () => {
+      expectSortBeingCalled(() => component.ngOnInit());
+    });
+  });
+
+  describe('set actions', () => {
+    it('sets the action list and calls sort', () => {
+      const actions = [{ actionId: 1234 }] as IScenarioAction[];
+
+      component.actions = actions;
+
+      expect(component.sortedActions).toEqual(actions);
+      expect(sortSpy).toHaveBeenCalledWith(actions, 'actionId', true);
+    });
+  });
+
+  it('sorts actions', () => {
+    expectSortBeingCalled(() => component.sortActions());
+  });
+
+  const expectSortBeingCalled = (whenFunction: () => void): void => {
+    const actions = [{ actionId: 1234 }] as IScenarioAction[];
+    component.sortedActions = actions;
+
+    whenFunction();
+
+    expect(sortSpy).toHaveBeenCalledWith(actions, 'actionId', true);
+  };
+});

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-actions-table.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { sort } from 'app/core/util/operators';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatePipe } from 'app/shared/date';
+import FormatMediumDatetimePipe from 'app/shared/date/format-medium-datetime.pipe';
+import SortDirective from 'app/shared/sort/sort.directive';
+import SortByDirective from 'app/shared/sort/sort-by.directive';
+
+import { IScenarioAction } from 'app/entities/scenario-action/scenario-action.model';
+import { ScenarioActionService } from 'app/entities/scenario-action/service/scenario-action.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-scenario-actions-table',
+  templateUrl: './scenario-actions-table.component.html',
+  imports: [RouterModule, SharedModule, DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe, SortDirective, SortByDirective],
+})
+export class ScenarioActionsTableComponent implements OnInit {
+  @Input()
+  ascending = true;
+
+  @Input()
+  predicate = 'actionId';
+
+  sortedActions: IScenarioAction[] | null = null;
+
+  constructor(protected scenarioActionService: ScenarioActionService) {}
+
+  ngOnInit(): void {
+    this.sortActions();
+  }
+
+  @Input() set actions(actions: IScenarioAction[] | null) {
+    this.sortedActions = actions ? actions.slice() : [];
+    this.sortActions();
+  }
+
+  trackId = (_index: number, item: IScenarioAction): number => this.scenarioActionService.getScenarioActionIdentifier(item);
+
+  sortActions(): void {
+    sort(this.sortedActions, this.predicate, this.ascending);
+  }
+}

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
@@ -38,6 +38,19 @@
         </dd>
       </dl>
 
+      <div ngbAccordion class="mb-3">
+        <div ngbAccordionItem>
+          <h2 ngbAccordionHeader>
+            <button ngbAccordionButton jhiTranslate="citrusSimulatorApp.testResult.stackTrace">Stacktrace</button>
+          </h2>
+          <div ngbAccordionCollapse>
+            <div ngbAccordionBody>
+              <ng-template>{{ scenarioExecution.testResult?.stackTrace }}</ng-template>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <h3 data-cy="messageDetailsHeading">
         <span jhiTranslate="citrusSimulatorApp.message.home.title">Messages</span>
       </h3>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
@@ -58,7 +58,7 @@
       </h3>
 
       <app-scenario-parameters-table
-        [scenarioParameters]="scenarioExecution.scenarioParameters ?? []"
+        [parameters]="scenarioExecution.scenarioParameters ?? []"
         predicate="createdDate"
       ></app-scenario-parameters-table>
 
@@ -72,6 +72,12 @@
         [messages]="scenarioExecution.scenarioMessages ?? []"
         predicate="createdDate"
       ></app-scenario-messages-table>
+
+      <h3 class="mb-3">
+        <span jhiTranslate="citrusSimulatorApp.scenarioAction.home.title">Scenario Actions</span>
+      </h3>
+
+      <app-scenario-actions-table [actions]="scenarioExecution.scenarioActions ?? []" predicate="createdDate"></app-scenario-actions-table>
 
       <button type="button" (click)="previousState()" class="btn btn-info mt-3">
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back">Back</span>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-center">
   <div class="col-8">
     <div *ngIf="scenarioExecution">
-      <h2 data-cy="scenarioExecutionDetailsHeading">
+      <h2>
         <span jhiTranslate="citrusSimulatorApp.scenarioExecution.detail.title">Scenario Execution</span>
       </h2>
 
@@ -51,15 +51,29 @@
         </div>
       </div>
 
-      <h3 data-cy="messageDetailsHeading">
-        <span jhiTranslate="citrusSimulatorApp.message.home.title">Messages</span>
+      <hr />
+
+      <h3 class="mb-3">
+        <span jhiTranslate="citrusSimulatorApp.scenarioParameter.home.title">Parameters</span>
       </h3>
+
+      <app-scenario-parameters-table
+        [scenarioParameters]="scenarioExecution.scenarioParameters ?? []"
+        predicate="createdDate"
+      ></app-scenario-parameters-table>
 
       <hr />
 
-      <app-message-table [messages]="scenarioExecution.scenarioMessages ?? []" predicate="createdDate"></app-message-table>
+      <h3 class="mb-3">
+        <span jhiTranslate="citrusSimulatorApp.message.home.title">Messages</span>
+      </h3>
 
-      <button type="button" (click)="previousState()" class="btn btn-info" data-cy="entityDetailsBackButton">
+      <app-scenario-messages-table
+        [messages]="scenarioExecution.scenarioMessages ?? []"
+        predicate="createdDate"
+      ></app-scenario-messages-table>
+
+      <button type="button" (click)="previousState()" class="btn btn-info mt-3">
         <fa-icon icon="arrow-left"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back">Back</span>
       </button>
     </div>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.ts
@@ -4,7 +4,8 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import SharedModule from 'app/shared/shared.module';
 import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 
-import { MessageTableComponent } from './message-table.component';
+import { ScenarioMessagesTableComponent } from './scenario-messages-table.component';
+import { ScenarioParametersTableComponent } from './scenario-parameters-table.component';
 
 import { IScenarioExecution } from '../scenario-execution.model';
 
@@ -12,7 +13,15 @@ import { IScenarioExecution } from '../scenario-execution.model';
   standalone: true,
   selector: 'app-scenario-execution-detail',
   templateUrl: './scenario-execution-detail.component.html',
-  imports: [SharedModule, RouterModule, DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe, MessageTableComponent],
+  imports: [
+    SharedModule,
+    RouterModule,
+    DurationPipe,
+    FormatMediumDatetimePipe,
+    FormatMediumDatePipe,
+    ScenarioMessagesTableComponent,
+    ScenarioParametersTableComponent,
+  ],
 })
 export class ScenarioExecutionDetailComponent {
   @Input() scenarioExecution: IScenarioExecution | null = null;

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-execution-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import SharedModule from 'app/shared/shared.module';
 import { DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe } from 'app/shared/date';
 
+import { ScenarioActionsTableComponent } from './scenario-actions-table.component';
 import { ScenarioMessagesTableComponent } from './scenario-messages-table.component';
 import { ScenarioParametersTableComponent } from './scenario-parameters-table.component';
 
@@ -19,6 +20,7 @@ import { IScenarioExecution } from '../scenario-execution.model';
     DurationPipe,
     FormatMediumDatetimePipe,
     FormatMediumDatePipe,
+    ScenarioActionsTableComponent,
     ScenarioMessagesTableComponent,
     ScenarioParametersTableComponent,
   ],

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.html
@@ -1,4 +1,4 @@
-<div class="table-responsive table-entities" id="entities" *ngIf="sortedMessages && sortedMessages.length > 0">
+<div class="table-responsive table-entities" id="entities" *ngIf="sortedMessages && sortedMessages.length > 0; else noMessages">
   <table class="table table-striped" aria-describedby="page-heading">
     <thead>
       <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="sortMessages()">
@@ -26,28 +26,21 @@
             <fa-icon class="p-1" icon="sort"></fa-icon>
           </div>
         </th>
-        <th scope="col" jhiSortBy="lastModifiedDate">
-          <div class="d-flex">
-            <span jhiTranslate="citrusSimulatorApp.message.lastModifiedDate">Last Modified Date</span>
-            <fa-icon class="p-1" icon="sort"></fa-icon>
-          </div>
-        </th>
         <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let message of sortedMessages; trackBy: trackId" data-cy="entityTable">
+      <tr *ngFor="let message of sortedMessages; trackBy: trackId">
         <td>
           <a [routerLink]="['/message', message.messageId, 'view']">{{ message.messageId }}</a>
         </td>
         <td>{{ message.direction }}</td>
         <td>{{ message.payload }}</td>
         <td>{{ message.createdDate | formatMediumDatetime }}</td>
-        <td>{{ message.lastModifiedDate | formatMediumDatetime }}</td>
         <td class="text-end">
           <div class="btn-group">
             <a [routerLink]="['/message-header']" [queryParams]="{ 'filter[messageId.in]': message.messageId }">
-              <button type="button" class="btn btn-info btn-sm" data-cy="filterOtherEntityButton">
+              <button type="button" class="btn btn-info btn-sm">
                 <fa-icon icon="heading"></fa-icon>
                 <span
                   class="d-none d-md-inline"
@@ -58,7 +51,7 @@
               </button>
             </a>
             <a [routerLink]="['/message', message.messageId, 'view']">
-              <button type="button" class="btn btn-info btn-sm" data-cy="entityDetailsButton">
+              <button type="button" class="btn btn-info btn-sm">
                 <fa-icon icon="eye"></fa-icon>
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
               </button>
@@ -69,3 +62,9 @@
     </tbody>
   </table>
 </div>
+
+<ng-template #noMessages>
+  <div class="alert alert-warning" id="no-result">
+    <span jhiTranslate="citrusSimulatorApp.message.home.notFound">No Messages found</span>
+  </div>
+</ng-template>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.spec.ts
@@ -4,35 +4,31 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import * as operators from 'app/core/util/operators';
 
-import { MessageService } from 'app/entities/message/service/message.service';
+import { IMessage } from 'app/entities/message/message.model';
 
-import { MessageTableComponent } from './message-table.component';
+import { ScenarioMessagesTableComponent } from './scenario-messages-table.component';
 
 import SpyInstance = jest.SpyInstance;
-import { IMessageHeader } from '../../message-header/message-header.model';
-import { IMessage } from '../../message/message.model';
 
 describe('Message Table Component', () => {
   let sortSpy: SpyInstance;
 
-  let service: MessageService;
-
-  let fixture: ComponentFixture<MessageTableComponent>;
-  let component: MessageTableComponent;
+  let fixture: ComponentFixture<ScenarioMessagesTableComponent>;
+  let component: ScenarioMessagesTableComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([{ path: 'message', component: MessageTableComponent }]),
+        RouterTestingModule.withRoutes([{ path: 'message', component: ScenarioMessagesTableComponent }]),
         HttpClientTestingModule,
-        MessageTableComponent,
+        ScenarioMessagesTableComponent,
       ],
       providers: [],
     })
-      .overrideTemplate(MessageTableComponent, '')
+      .overrideTemplate(ScenarioMessagesTableComponent, '')
       .compileComponents();
 
-    fixture = TestBed.createComponent(MessageTableComponent);
+    fixture = TestBed.createComponent(ScenarioMessagesTableComponent);
     component = fixture.componentInstance;
 
     sortSpy = jest.spyOn(operators, 'sort');
@@ -41,7 +37,7 @@ describe('Message Table Component', () => {
 
   describe('ngOnInit', () => {
     it('sorts messages', () => {
-      extracted(() => component.ngOnInit());
+      expectSortBeingCalled(() => component.ngOnInit());
     });
   });
 
@@ -57,10 +53,10 @@ describe('Message Table Component', () => {
   });
 
   it('sorts messages', () => {
-    extracted(() => component.sortMessages());
+    expectSortBeingCalled(() => component.sortMessages());
   });
 
-  const extracted = (whenFunction: () => void): void => {
+  const expectSortBeingCalled = (whenFunction: () => void): void => {
     const messages = [{ messageId: 1234 }] as IMessage[];
     component.sortedMessages = messages;
 

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-messages-table.component.ts
@@ -14,11 +14,11 @@ import SortByDirective from 'app/shared/sort/sort-by.directive';
 
 @Component({
   standalone: true,
-  selector: 'app-message-table',
-  templateUrl: './message-table.component.html',
+  selector: 'app-scenario-messages-table',
+  templateUrl: './scenario-messages-table.component.html',
   imports: [RouterModule, SharedModule, DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe, SortDirective, SortByDirective],
 })
-export class MessageTableComponent implements OnInit {
+export class ScenarioMessagesTableComponent implements OnInit {
   @Input()
   ascending = true;
 

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.html
@@ -1,0 +1,57 @@
+<div class="table-responsive table-entities" id="entities" *ngIf="sortedParameters && sortedParameters.length > 0; else noParameters">
+  <table class="table table-striped" aria-describedby="page-heading">
+    <thead>
+      <th scope="col" jhiSortBy="parameterId">
+        <div class="d-flex">
+          <span jhiTranslate="global.field.id">ID</span>
+          <fa-icon class="p-1" icon="sort"></fa-icon>
+        </div>
+      </th>
+      <th scope="col" jhiSortBy="name">
+        <div class="d-flex">
+          <span jhiTranslate="citrusSimulatorApp.scenarioParameter.name">Name</span>
+          <fa-icon class="p-1" icon="sort"></fa-icon>
+        </div>
+      </th>
+      <th scope="col" jhiSortBy="controlType">
+        <div class="d-flex">
+          <span jhiTranslate="citrusSimulatorApp.scenarioParameter.controlType">Control Type</span>
+          <fa-icon class="p-1" icon="sort"></fa-icon>
+        </div>
+      </th>
+      <th scope="col" jhiSortBy="value">
+        <div class="d-flex">
+          <span jhiTranslate="citrusSimulatorApp.scenarioParameter.value">Value</span>
+          <fa-icon class="p-1" icon="sort"></fa-icon>
+        </div>
+      </th>
+      <th scope="col"></th>
+    </thead>
+    <tbody>
+      <tr *ngFor="let scenarioParameter of sortedParameters; trackBy: trackId">
+        <td>
+          <a [routerLink]="['/scenario-parameter', scenarioParameter.parameterId, 'view']">{{ scenarioParameter.parameterId }}</a>
+        </td>
+        <td>{{ scenarioParameter.name }}</td>
+        <td>{{ scenarioParameter.controlType }}</td>
+        <td>{{ scenarioParameter.value }}</td>
+        <td class="text-end">
+          <div class="btn-group">
+            <a [routerLink]="['/scenario-parameter', scenarioParameter.parameterId, 'view']">
+              <button type="button" class="btn btn-info btn-sm">
+                <fa-icon icon="eye"></fa-icon>
+                <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+              </button>
+            </a>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<ng-template #noParameters>
+  <div class="alert alert-warning" id="no-result">
+    <span jhiTranslate="citrusSimulatorApp.scenarioParameter.home.notFound">No Scenario Parameters found</span>
+  </div>
+</ng-template>

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.spec.ts
@@ -1,0 +1,67 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import * as operators from 'app/core/util/operators';
+
+import { IScenarioParameter } from 'app/entities/scenario-parameter/scenario-parameter.model';
+
+import { ScenarioParametersTableComponent } from './scenario-parameters-table.component';
+
+import SpyInstance = jest.SpyInstance;
+
+describe('Message Table Component', () => {
+  let sortSpy: SpyInstance;
+
+  let fixture: ComponentFixture<ScenarioParametersTableComponent>;
+  let component: ScenarioParametersTableComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes([{ path: 'parameter', component: ScenarioParametersTableComponent }]),
+        HttpClientTestingModule,
+        ScenarioParametersTableComponent,
+      ],
+      providers: [],
+    })
+      .overrideTemplate(ScenarioParametersTableComponent, '')
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ScenarioParametersTableComponent);
+    component = fixture.componentInstance;
+
+    sortSpy = jest.spyOn(operators, 'sort');
+    sortSpy.mockClear();
+  });
+
+  describe('ngOnInit', () => {
+    it('sorts parameters', () => {
+      expectSortBeingCalled(() => component.ngOnInit());
+    });
+  });
+
+  describe('set parameters', () => {
+    it('sets the parameter list and calls sort', () => {
+      const parameters = [{ parameterId: 1234 }] as IScenarioParameter[];
+
+      component.scenarioParameters = parameters;
+
+      expect(component.sortedParameters).toEqual(parameters);
+      expect(sortSpy).toHaveBeenCalledWith(parameters, 'parameterId', true);
+    });
+  });
+
+  it('sorts parameters', () => {
+    expectSortBeingCalled(() => component.sortParameters());
+  });
+
+  const expectSortBeingCalled = (whenFunction: () => void): void => {
+    const parameters = [{ parameterId: 1234 }] as IScenarioParameter[];
+    component.scenarioParameters = parameters;
+
+    whenFunction();
+
+    expect(sortSpy).toHaveBeenCalledWith(parameters, 'parameterId', true);
+  };
+});

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.spec.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.spec.ts
@@ -45,7 +45,7 @@ describe('Message Table Component', () => {
     it('sets the parameter list and calls sort', () => {
       const parameters = [{ parameterId: 1234 }] as IScenarioParameter[];
 
-      component.scenarioParameters = parameters;
+      component.parameters = parameters;
 
       expect(component.sortedParameters).toEqual(parameters);
       expect(sortSpy).toHaveBeenCalledWith(parameters, 'parameterId', true);
@@ -58,7 +58,7 @@ describe('Message Table Component', () => {
 
   const expectSortBeingCalled = (whenFunction: () => void): void => {
     const parameters = [{ parameterId: 1234 }] as IScenarioParameter[];
-    component.scenarioParameters = parameters;
+    component.parameters = parameters;
 
     whenFunction();
 

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.ts
@@ -33,7 +33,7 @@ export class ScenarioParametersTableComponent implements OnInit {
     this.sortParameters();
   }
 
-  @Input() set scenarioParameters(parameters: IScenarioParameter[] | null) {
+  @Input() set parameters(parameters: IScenarioParameter[] | null) {
     this.sortedParameters = parameters ? parameters.slice() : [];
     this.sortParameters();
   }

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/detail/scenario-parameters-table.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { sort } from 'app/core/util/operators';
+
+import { IScenarioParameter } from 'app/entities/scenario-parameter/scenario-parameter.model';
+import { ScenarioParameterService } from 'app/entities/scenario-parameter/service/scenario-parameter.service';
+
+import SharedModule from 'app/shared/shared.module';
+import { DurationPipe, FormatMediumDatePipe } from 'app/shared/date';
+import FormatMediumDatetimePipe from 'app/shared/date/format-medium-datetime.pipe';
+import SortDirective from 'app/shared/sort/sort.directive';
+import SortByDirective from 'app/shared/sort/sort-by.directive';
+
+@Component({
+  standalone: true,
+  selector: 'app-scenario-parameters-table',
+  templateUrl: './scenario-parameters-table.component.html',
+  imports: [RouterModule, SharedModule, DurationPipe, FormatMediumDatetimePipe, FormatMediumDatePipe, SortDirective, SortByDirective],
+})
+export class ScenarioParametersTableComponent implements OnInit {
+  @Input()
+  ascending = true;
+
+  @Input()
+  predicate = 'parameterId';
+
+  sortedParameters: IScenarioParameter[] | null = null;
+
+  constructor(protected scenarioParameterService: ScenarioParameterService) {}
+
+  ngOnInit(): void {
+    this.sortParameters();
+  }
+
+  @Input() set scenarioParameters(parameters: IScenarioParameter[] | null) {
+    this.sortedParameters = parameters ? parameters.slice() : [];
+    this.sortParameters();
+  }
+
+  trackId = (_index: number, item: IScenarioParameter): number => this.scenarioParameterService.getScenarioParameterIdentifier(item);
+
+  sortParameters(): void {
+    sort(this.sortedParameters, this.predicate, this.ascending);
+  }
+}

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/scenario-execution.model.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/scenario-execution.model.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs/esm';
 
 import { IMessage } from 'app/entities/message/message.model';
+import { IScenarioParameter } from 'app/entities/scenario-parameter/scenario-parameter.model';
 import { ITestResult } from 'app/entities/test-result/test-result.model';
 
 export interface IScenarioExecution {
@@ -10,4 +11,5 @@ export interface IScenarioExecution {
   scenarioName?: string | null;
   testResult?: ITestResult | null;
   scenarioMessages?: IMessage[] | null;
+  scenarioParameters?: IScenarioParameter[] | null;
 }

--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/scenario-execution.model.ts
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/scenario-execution.model.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs/esm';
 
 import { IMessage } from 'app/entities/message/message.model';
+import { IScenarioAction } from 'app/entities/scenario-action/scenario-action.model';
 import { IScenarioParameter } from 'app/entities/scenario-parameter/scenario-parameter.model';
 import { ITestResult } from 'app/entities/test-result/test-result.model';
 
@@ -10,6 +11,7 @@ export interface IScenarioExecution {
   endDate?: dayjs.Dayjs | null;
   scenarioName?: string | null;
   testResult?: ITestResult | null;
+  scenarioActions?: IScenarioAction[] | null;
   scenarioMessages?: IMessage[] | null;
   scenarioParameters?: IScenarioParameter[] | null;
 }


### PR DESCRIPTION
last improvements for the scenario details view. makes it more or less equal to the "old" view. see issue for more information. closes #233 for the time being.

## with collaped stacktrace

![2024-05-13-152906_3840x2160_scrot](https://github.com/citrusframework/citrus-simulator/assets/12272901/31e2db2f-29ea-4aea-8aa1-e14ac481381b)

## with expanded stacktrace

![2024-05-13-152914_3840x2160_scrot](https://github.com/citrusframework/citrus-simulator/assets/12272901/6f2867be-9ad0-469b-aa5a-0437591d24d9)
