### PR TITLE
fix(#288): replace UI button

### DIFF
--- a/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.html
+++ b/simulator-ui/src/main/webapp/app/entities/scenario-execution/list/scenario-execution.component.html
@@ -94,7 +94,7 @@
               <a [routerLink]="['/scenario-parameter']" [queryParams]="{ 'filter[scenarioExecutionId.in]': scenarioExecution.executionId }">
                 <button type="button" class="btn btn-info btn-sm" data-cy="filterOtherEntityButton">
                   <fa-icon icon="gears"></fa-icon>
-                  <span class="d-none d-md-inline" jhiTranslate="citrusSimulatorApp.scenarioExecution.scenarioMessages">Parameters</span>
+                  <span class="d-none d-md-inline" jhiTranslate="citrusSimulatorApp.scenarioExecution.scenarioParameters">Parameters</span>
                 </button>
               </a>
               <a [routerLink]="['/scenario-execution', scenarioExecution.executionId, 'view']">


### PR DESCRIPTION
closes #288.

![image](https://github.com/citrusframework/citrus-simulator/assets/12272901/f468a43d-1a10-48f7-a9ba-fedc8a3c2eec)
