### PR TITLE
fix(#281): fix delete test-result in backend

### DIFF
--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/model/TestResult.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/model/TestResult.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.CascadeType.REMOVE;
 import static java.util.Objects.nonNull;
 import static lombok.AccessLevel.NONE;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
@@ -132,7 +133,7 @@ public class TestResult extends AbstractAuditingEntity<TestResult, Long> impleme
     private String failureType;
 
     @ToString.Exclude
-    @OneToOne(mappedBy = "testResult")
+    @OneToOne(mappedBy = "testResult", cascade = {REMOVE})
     private ScenarioExecution scenarioExecution;
 
     /**

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/web/rest/TestResultResourceIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/web/rest/TestResultResourceIT.java
@@ -98,7 +98,11 @@ public class TestResultResourceIT {
      * if they test an entity which requires the current entity.
      */
     public static TestResult createEntity(EntityManager entityManager) {
-        return TestResult.builder()
+        return createEntity(entityManager, false);
+    }
+
+    public static TestResult createEntity(EntityManager entityManager, boolean includeScenarioExecution) {
+        var testResult = TestResult.builder()
             .status(DEFAULT_STATUS)
             .testName(DEFAULT_TEST_NAME)
             .className(DEFAULT_CLASS_NAME)
@@ -108,6 +112,14 @@ public class TestResultResourceIT {
             .createdDate(DEFAULT_CREATED_DATE)
             .lastModifiedDate(DEFAULT_LAST_MODIFIED_DATE)
             .build();
+
+        if (includeScenarioExecution) {
+            var scenarioExecution = ScenarioExecutionResourceIT.createEntity(entityManager);
+            entityManager.persist(scenarioExecution);
+            testResult.setScenarioExecution(scenarioExecution);
+        }
+
+        return testResult;
     }
 
     /**
@@ -758,16 +770,18 @@ public class TestResultResourceIT {
     @Test
     @Transactional
     void deleteAllTestResults() throws Exception {
-        TestParameter testParameter = getOrCreateTestParameterWithTestResult();
+        testResult = createEntity(entityManager, true);
+        getOrCreateTestParameterWithTestResult();
 
-        int databaseSizeBeforeDelete = testResultRepository.findAll().size();
+        assertThat(testResultRepository.findAll())
+            .isNotEmpty();
 
         mockMvc
             .perform(delete(ENTITY_API_URL).accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
 
-        List<TestResult> eventList = testResultRepository.findAll();
-        assertThat(eventList).hasSize(databaseSizeBeforeDelete - 1);
+        assertThat(testResultRepository.findAll())
+            .isEmpty();
     }
 
     private TestParameter getOrCreateTestParameterWithTestResult() {


### PR DESCRIPTION
Added a cascade all to TestResult and ScenarioExecution relation to propagate the delete of the TestReuslt to the ScenarioExecution