### PR TITLE
improved scenario execution endpoint fetch performance

### DIFF
--- a/simulator-docs/src/main/asciidoc/rest-api.adoc
+++ b/simulator-docs/src/main/asciidoc/rest-api.adoc
@@ -28,7 +28,21 @@ The endpoint `/api/test-results` additionally supports the `DELETE` request that
 === Receive SINGLE Test-Parameter
 
 A `TestParameter` is uniquely identified by a composite key, consisting of the `TestResult` ID and the `TestParameter` key.
-To retrieve a single `TestParameter`, use the `GET /{testResultId}/{key}` endpoint.
+To retrieve a single `TestParameter`, use the `GET /api/test-parameters/{testResultId}/{key}` endpoint. all recorded Test Results and Executions.
+
+[[receive-scenario-execution-details]]
+=== Receive Scenario Execution with Details
+
+The `ScenarioExecution` is also unique in regard to the amount of details that _could_ be extracted from it.
+However, more information (almost) always comes at the cost of performance.
+Thus, the `/api/scenario-executions` endpoint offers four unique boolean query parameters:
+
+* `includeActions`: When `true`, additionally fetches related `ScenarioAction`
+* `includeMessages`: When `true`, additionally fetches related `Message` (without `MessageHeader`)
+* `includeMessageHeaders`: When `true`, additionally fetches related `Message` and `MessageHeaders`
+* `includeParameters`: When `true`, additionally fetches related `ScenarioParameter`
+
+They are all being set to `false` by default.
 
 [[scenario-resource]]
 === Scenario Resource

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepository.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepository.java
@@ -41,8 +41,4 @@ public interface ScenarioExecutionRepository extends JpaRepository<ScenarioExecu
 
     @EntityGraph(attributePaths = {"testResult", "scenarioParameters", "scenarioActions", "scenarioMessages", "scenarioMessages.headers"})
     Optional<ScenarioExecution> findOneByExecutionId(@Param("executionId") Long executionId);
-
-    @Query("FROM ScenarioExecution WHERE executionId IN :scenarioExecutionIds")
-    @EntityGraph(attributePaths = {"testResult", "scenarioParameters", "scenarioActions", "scenarioMessages", "scenarioMessages.headers"})
-    Page<ScenarioExecution> findAllWhereExecutionIdIn(@Param("scenarioExecutionIds") List<Long> scenarioExecutionIds, Pageable pageable);
 }

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/web/rest/MessageHeaderResourceIT.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/web/rest/MessageHeaderResourceIT.java
@@ -99,6 +99,7 @@ public class MessageHeaderResourceIT {
             message = TestUtil.findAll(entityManager, Message.class).get(0);
         }
         messageHeader.setMessage(message);
+        message.addHeader(messageHeader);
         return messageHeader;
     }
 


### PR DESCRIPTION
this makes loading `ScenarioExecutions` "standalone" by default. no additional entities will be fetched without defined query params. wheres previously the whole entity was fetched including all relationships. superfluous information was only stripped afterwards.

the standard sql is:

```sql
select se1_0.execution_id,
       se1_0.end_date,
       se1_0.scenario_name,
       se1_0.start_date,
       tr1_0.id,
       tr1_0.class_name,
       tr1_0.created_date,
       tr1_0.error_message,
       tr1_0.failure_type,
       tr1_0.last_modified_date,
       tr1_0.stack_trace,
       tr1_0.status,
       tr1_0.test_name
from scenario_execution se1_0
         left join test_result tr1_0 on tr1_0.id = se1_0.test_result_id
where se1_0.execution_id in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
order by se1_0.execution_id
```