### PR TITLE
feat: persist only failed scenarios

### DIFF
--- a/simulator-docs/src/main/asciidoc/concepts-advanced.adoc
+++ b/simulator-docs/src/main/asciidoc/concepts-advanced.adoc
@@ -147,9 +147,29 @@ citrus.simulator.simulation-results.reset-enabled=false
 ----
 
 .Example `application.yml`
+[source, yaml]
 ----
 citrus:
   simulator:
-    test-results:
-        reset-enabeld: false
+    simulation-results:
+      reset-enabled: false
+----
+
+Likewise, data growth in long-lived simulators is uncontrollable.
+You can reduce the amount of persisted data dramatically by persisting only failed scenarios.
+When enabled, successful scenario executions — including their actions, messages, and parameters — are deleted from the database immediately after completion, significantly reducing persistence overhead for high-throughput simulators.
+
+.Example `application.properties`
+[source, properties]
+----
+citrus.simulator.simulation-results.persist-only-failed-scenarios=true
+----
+
+.Example `application.yml`
+[source, yaml]
+----
+citrus:
+  simulator:
+    simulation-results:
+      persist-only-failed-scenarios: true
 ----

--- a/simulator-docs/src/main/asciidoc/concepts-advanced.adoc
+++ b/simulator-docs/src/main/asciidoc/concepts-advanced.adoc
@@ -147,9 +147,29 @@ citrus.simulator.simulation-results.reset-enabled=false
 ----
 
 .Example `application.yml`
+[source, yaml]
 ----
 citrus:
   simulator:
-    test-results:
-        reset-enabeld: false
+    simulation-results:
+      reset-enabled: false
+----
+
+Likewise, data growth in long-lived simulators is uncontrollable.
+You can reduce the amount of persisted data by persisting only failed scenarios.
+When enabled, successful scenario executions — including their actions, messages, and parameters — are deleted from the database immediately after completion, significantly reducing persistence overhead for high-throughput simulators.
+
+.Example `application.properties`
+[source, properties]
+----
+citrus.simulator.simulation-results.persist-only-failed-scenarios=true
+----
+
+.Example `application.yml`
+[source, yaml]
+----
+citrus:
+  simulator:
+    simulation-results:
+      persist-only-failed-scenarios: true
 ----

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/config/SimulatorConfigurationProperties.java
@@ -126,5 +126,13 @@ public class SimulatorConfigurationProperties implements EnvironmentAware, Initi
          * Specifies whether the test results shall be deletable or not. If you're working with a long-lived citrus-simulator and disable this, make sure to manually take care of housekeeping!
          */
         private boolean resetEnabled = true;
+
+        /**
+         * When enabled, only execution data of <em>failed</em> scenarios is persisted.
+         * Successful scenario executions (including their actions, messages and parameters) are deleted from the database right after completion, reducing persistence overhead significantly for high-throughput simulators.
+         * <p>
+         * Defaults to {@code false} so that all scenario execution data is persisted (existing behavior).
+         */
+        private boolean persistOnlyFailedScenarios = false;
     }
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
@@ -24,6 +24,7 @@ import org.citrusframework.actions.SleepAction;
 import org.citrusframework.common.Described;
 import org.citrusframework.report.AbstractTestListener;
 import org.citrusframework.report.TestActionListener;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.service.ScenarioActionService;
 import org.citrusframework.simulator.service.ScenarioExecutionService;
 import org.slf4j.Logger;
@@ -55,10 +56,12 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
 
     private final ScenarioActionService scenarioActionService;
     private final ScenarioExecutionService scenarioExecutionService;
+    private final SimulatorConfigurationProperties simulatorConfigurationProperties;
 
-    public SimulatorStatusListener(ScenarioActionService scenarioActionService, ScenarioExecutionService scenarioExecutionService) {
+    public SimulatorStatusListener(ScenarioActionService scenarioActionService, ScenarioExecutionService scenarioExecutionService, SimulatorConfigurationProperties simulatorConfigurationProperties) {
         this.scenarioActionService = scenarioActionService;
         this.scenarioExecutionService = scenarioExecutionService;
+        this.simulatorConfigurationProperties = simulatorConfigurationProperties;
     }
 
     @Override
@@ -84,9 +87,15 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
             testResult = success(testCase.getName(), testCase.getTestClass().getSimpleName());
         }
 
-        scenarioExecutionService.completeScenarioExecution(getScenarioExecutionId(testCase), new org.citrusframework.simulator.model.TestResult(testResult));
+        long scenarioExecutionId = getScenarioExecutionId(testCase);
 
-        logger.info("Scenario succeeded: {}", testResult);
+        if (simulatorConfigurationProperties.getSimulationResults().isPersistOnlyFailedScenarios()) {
+            scenarioExecutionService.deleteScenarioExecution(scenarioExecutionId);
+            logger.info("Scenario succeeded and execution data discarded (persistOnlyFailedScenarios=true): {}", testResult);
+        } else {
+            scenarioExecutionService.completeScenarioExecution(scenarioExecutionId, new org.citrusframework.simulator.model.TestResult(testResult));
+            logger.info("Scenario succeeded: {}", testResult);
+        }
     }
 
     @Override

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/listener/SimulatorStatusListener.java
@@ -24,6 +24,7 @@ import org.citrusframework.actions.SleepAction;
 import org.citrusframework.api.common.Described;
 import org.citrusframework.report.AbstractTestListener;
 import org.citrusframework.report.TestActionListener;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.service.ScenarioActionService;
 import org.citrusframework.simulator.service.ScenarioExecutionService;
 import org.slf4j.Logger;
@@ -55,10 +56,12 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
 
     private final ScenarioActionService scenarioActionService;
     private final ScenarioExecutionService scenarioExecutionService;
+    private final SimulatorConfigurationProperties simulatorConfigurationProperties;
 
-    public SimulatorStatusListener(ScenarioActionService scenarioActionService, ScenarioExecutionService scenarioExecutionService) {
+    public SimulatorStatusListener(ScenarioActionService scenarioActionService, ScenarioExecutionService scenarioExecutionService, SimulatorConfigurationProperties simulatorConfigurationProperties) {
         this.scenarioActionService = scenarioActionService;
         this.scenarioExecutionService = scenarioExecutionService;
+        this.simulatorConfigurationProperties = simulatorConfigurationProperties;
     }
 
     @Override
@@ -84,9 +87,15 @@ public class SimulatorStatusListener extends AbstractTestListener implements Tes
             testResult = success(testCase.getName(), testCase.getTestClass().getSimpleName());
         }
 
-        scenarioExecutionService.completeScenarioExecution(getScenarioExecutionId(testCase), new org.citrusframework.simulator.model.TestResult(testResult));
+        long scenarioExecutionId = getScenarioExecutionId(testCase);
 
-        logger.info("Scenario succeeded: {}", testResult);
+        if (simulatorConfigurationProperties.getSimulationResults().isPersistOnlyFailedScenarios()) {
+            scenarioExecutionService.deleteScenarioExecution(scenarioExecutionId);
+            logger.info("Scenario succeeded and execution data discarded (persistOnlyFailedScenarios=true): {}", testResult);
+        } else {
+            scenarioExecutionService.completeScenarioExecution(scenarioExecutionId, new org.citrusframework.simulator.model.TestResult(testResult));
+            logger.info("Scenario succeeded: {}", testResult);
+        }
     }
 
     @Override

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/ScenarioExecutionService.java
@@ -80,4 +80,12 @@ public interface ScenarioExecutionService {
      * @return the updated entity.
      */
     ScenarioExecution completeScenarioExecution(long scenarioExecutionId, TestResult testResult);
+
+    /**
+     * Delete a {@link ScenarioExecution} and all of its associated data (actions, messages,
+     * parameters) by execution id.
+     *
+     * @param scenarioExecutionId the id of the entity to delete.
+     */
+    void deleteScenarioExecution(long scenarioExecutionId);
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/ScenarioExecutionServiceImpl.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/ScenarioExecutionServiceImpl.java
@@ -114,4 +114,10 @@ public class ScenarioExecutionServiceImpl implements ScenarioExecutionService {
 
         return scenarioExecutionRepository.save(scenarioExecution);
     }
+
+    @Override
+    public void deleteScenarioExecution(long scenarioExecutionId) {
+        logger.debug("Request to delete ScenarioExecution : {}", scenarioExecutionId);
+        scenarioExecutionRepository.deleteById(scenarioExecutionId);
+    }
 }

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/listener/SimulatorStatusListenerTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/listener/SimulatorStatusListenerTest.java
@@ -23,6 +23,7 @@ import org.citrusframework.TestCase;
 import org.citrusframework.TestResult;
 import org.citrusframework.actions.SleepAction;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.service.ScenarioActionService;
 import org.citrusframework.simulator.service.ScenarioExecutionService;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,11 +59,14 @@ class SimulatorStatusListenerTest {
     @Mock
     private ScenarioExecutionService scenarioExecutionServiceMock;
 
+    @Mock
+    private SimulatorConfigurationProperties simulatorConfigurationPropertiesMock;
+
     private SimulatorStatusListener fixture;
 
     @BeforeEach
     void setup() {
-        fixture = new SimulatorStatusListener(scenarioActionServiceMock, scenarioExecutionServiceMock);
+        fixture = new SimulatorStatusListener(scenarioActionServiceMock, scenarioExecutionServiceMock, simulatorConfigurationPropertiesMock);
     }
 
     @Nested
@@ -162,6 +166,9 @@ class SimulatorStatusListenerTest {
 
             var scenarioExecutionId = createAndGetScenarioExecutionId(defaultTestCaseMock);
 
+            var simulationResultsMock = new SimulatorConfigurationProperties.SimulationResults();
+            doReturn(simulationResultsMock).when(simulatorConfigurationPropertiesMock).getSimulationResults();
+
             // Act
             fixture.onTestSuccess(defaultTestCaseMock);
 
@@ -178,11 +185,34 @@ class SimulatorStatusListenerTest {
 
             var scenarioExecutionId = createAndGetScenarioExecutionId(testCaseMock);
 
+            var simulationResultsMock = new SimulatorConfigurationProperties.SimulationResults();
+            doReturn(simulationResultsMock).when(simulatorConfigurationPropertiesMock).getSimulationResults();
+
             // Act
             fixture.onTestSuccess(testCaseMock);
 
             // Assert
             verify(scenarioExecutionServiceMock).completeScenarioExecution(eq(scenarioExecutionId), argThat(r -> r.getStatus() == SUCCESS && r.getTestParameters().isEmpty()));
+        }
+
+        @Test
+        void shouldDeleteScenarioExecutionWhenPersistOnlyFailedScenariosIsEnabled() {
+            // Arrange
+            var simulationResults = new SimulatorConfigurationProperties.SimulationResults();
+            simulationResults.setPersistOnlyFailedScenarios(true);
+            doReturn(simulationResults).when(simulatorConfigurationPropertiesMock).getSimulationResults();
+
+            var testCaseMock = mock(TestCase.class);
+            doReturn("shouldDeleteScenarioExecutionWhenPersistOnlyFailedScenariosIsEnabled").when(testCaseMock).getName();
+            doReturn(getClass()).when(testCaseMock).getTestClass();
+
+            var scenarioExecutionId = createAndGetScenarioExecutionId(testCaseMock);
+
+            // Act
+            fixture.onTestSuccess(testCaseMock);
+
+            // Assert
+            verify(scenarioExecutionServiceMock).deleteScenarioExecution(scenarioExecutionId);
         }
     }
 


### PR DESCRIPTION
introduces flag: `citrus.simulator.simulation-results.persist-only-failed-scenarios`.
when enabled, only execution data of _failed_ scenarios is persisted.
         * Successful scenario executions (including their actions, messages and parameters) are deleted from the database right after completion, reducing persistence overhead significantly for high-throughput simulators.
         * Defaults to `false` so that all scenario execution data is persisted (existing behavior).