### PR TITLE
expose simulation mappings for consumers

### DIFF
--- a/simulator-ui/pom.xml
+++ b/simulator-ui/pom.xml
@@ -152,6 +152,10 @@
           <target>${java.version}</target>
           <annotationProcessorPaths>
             <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+            <path>
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-configuration-processor</artifactId>
               <version>${spring-boot.version}</version>

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SecurityConfiguration.java
@@ -16,17 +16,7 @@
 
 package org.citrusframework.simulator.ui.config;
 
-import static java.util.Objects.nonNull;
-
-import jakarta.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import org.citrusframework.simulator.http.SimulatorRestAdapter;
-import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
 import org.citrusframework.simulator.ui.filter.SpaWebFilter;
-import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
-import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -42,33 +32,25 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 @Configuration
 public class SecurityConfiguration {
 
-    private final @Nullable SimulatorRestConfigurationProperties simulatorRestConfigurationProperties;
-    private final @Nullable SimulatorRestAdapter simulatorRestAdapter;
-
-    private final @Nullable SimulatorWebServiceConfigurationProperties  simulatorWebServiceConfigurationProperties;
-    private final @Nullable SimulatorWebServiceAdapter simulatorWebServiceAdapter;
-
+    private final SimulationMappings simulationMappings;
     private final String contentSecurityPolicy;
 
     private final String actuatorPath;
     private final String h2ConsolePath;
 
     public SecurityConfiguration(
+        SimulationMappings simulationMappings,
         SimulatorUiConfigurationProperties simulatorUiConfigurationProperties,
-        @Autowired(required = false) @Nullable SimulatorRestConfigurationProperties simulatorRestConfigurationProperties,
-        @Autowired(required = false) @Nullable SimulatorRestAdapter simulatorRestAdapter,
-        @Autowired(required = false) @Nullable SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationProperties,
-        @Autowired(required = false) @Nullable SimulatorWebServiceAdapter simulatorWebServiceAdapter,
         @Value("${management.endpoints.web.base-path:/api/manage}") String actuatorPath,
         @Value("${spring.h2.console.path:/h2-console}") String h2ConsolePath
     ) {
-        this.simulatorRestConfigurationProperties = simulatorRestConfigurationProperties;
-        this.simulatorRestAdapter = simulatorRestAdapter;
-        this.simulatorWebServiceConfigurationProperties = simulatorWebServiceConfigurationProperties;
-        this.simulatorWebServiceAdapter = simulatorWebServiceAdapter;
+        this.simulationMappings = simulationMappings;
 
         this.contentSecurityPolicy = simulatorUiConfigurationProperties.getSecurity().getContentSecurityPolicy();
 
@@ -83,7 +65,7 @@ public class SecurityConfiguration {
      * {@link AntPathRequestMatcher} for matching.
      */
     private static AntPathRequestMatcher[] createMatchers(List<String> urlMappings) {
-        List<AntPathRequestMatcher> matchers =  urlMappings.stream()
+        List<AntPathRequestMatcher> matchers = urlMappings.stream()
             .map(AntPathRequestMatcher::new)
             .toList();
 
@@ -137,31 +119,11 @@ public class SecurityConfiguration {
     }
 
     private RequestMatcher getSimulationEndpointsRequestMatcher() {
-        List<String> urlMappings = new ArrayList<>();
-
-        addRestMatchers(urlMappings);
-        addWebServiceMatchers(urlMappings);
+        var urlMappings = Stream.of(
+            this.simulationMappings.getUrlMappings(),
+            this.simulationMappings.getServletMappings()
+        ).flatMap(List::stream).toList();
 
         return new OrRequestMatcher(createMatchers(urlMappings));
-    }
-
-    private void addWebServiceMatchers(List<String> urlMappings) {
-        if (nonNull(simulatorWebServiceConfigurationProperties)
-            && nonNull(simulatorWebServiceAdapter)
-            && simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties) != null) {
-            urlMappings.addAll(simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties));
-        } else if (nonNull(simulatorWebServiceConfigurationProperties)
-            && simulatorWebServiceConfigurationProperties.getServletMappings() != null) {
-            urlMappings.addAll(simulatorWebServiceConfigurationProperties.getServletMappings());
-        }
-    }
-
-    private void addRestMatchers(List<String> urlMappings) {
-        if (nonNull(simulatorRestConfigurationProperties)
-            && nonNull(simulatorRestAdapter)) {
-            urlMappings.addAll(simulatorRestAdapter.urlMappings(simulatorRestConfigurationProperties));
-        } else if (nonNull(simulatorRestConfigurationProperties)) {
-            urlMappings.addAll(simulatorRestConfigurationProperties.getUrlMappings());
-        }
     }
 }

--- a/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SimulationMappings.java
+++ b/simulator-ui/src/main/java/org/citrusframework/simulator/ui/config/SimulationMappings.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.ui.config;
+
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.citrusframework.simulator.http.SimulatorRestAdapter;
+import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
+import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.nonNull;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+@Component
+@AllArgsConstructor
+public class SimulationMappings {
+
+    private final @Nullable SimulatorRestConfigurationProperties simulatorRestConfigurationProperties;
+    private final @Nullable SimulatorRestAdapter simulatorRestAdapter;
+
+    private final @Nullable SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationProperties;
+    private final @Nullable SimulatorWebServiceAdapter simulatorWebServiceAdapter;
+
+    public List<String> getServletMappings() {
+        List<String> urlMappings = new ArrayList<>();
+
+        if (nonNull(simulatorWebServiceConfigurationProperties)
+            && nonNull(simulatorWebServiceAdapter)
+            && !isEmpty(simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties))) {
+            urlMappings.addAll(simulatorWebServiceAdapter.servletMappings(simulatorWebServiceConfigurationProperties));
+        } else if (nonNull(simulatorWebServiceConfigurationProperties)
+            && !isEmpty(simulatorWebServiceConfigurationProperties.getServletMappings())) {
+            urlMappings.addAll(simulatorWebServiceConfigurationProperties.getServletMappings());
+        }
+
+        return urlMappings;
+    }
+
+    public List<String> getUrlMappings() {
+        List<String> urlMappings = new ArrayList<>();
+
+        if (nonNull(simulatorRestConfigurationProperties)
+            && nonNull(simulatorRestAdapter)) {
+            urlMappings.addAll(simulatorRestAdapter.urlMappings(simulatorRestConfigurationProperties));
+        } else if (nonNull(simulatorRestConfigurationProperties)
+            && !isEmpty(simulatorRestConfigurationProperties.getUrlMappings())) {
+            urlMappings.addAll(simulatorRestConfigurationProperties.getUrlMappings());
+        }
+
+        return urlMappings;
+    }
+}

--- a/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SimulationMappingsTest.java
+++ b/simulator-ui/src/test/java/org/citrusframework/simulator/ui/config/SimulationMappingsTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.ui.config;
+
+import org.citrusframework.simulator.http.SimulatorRestAdapter;
+import org.citrusframework.simulator.http.SimulatorRestConfigurationProperties;
+import org.citrusframework.simulator.ws.SimulatorWebServiceAdapter;
+import org.citrusframework.simulator.ws.SimulatorWebServiceConfigurationProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SimulationMappingsTest {
+
+    @Mock
+    private SimulatorRestConfigurationProperties simulatorRestConfigurationPropertiesMock;
+
+    @Mock
+    private SimulatorRestAdapter simulatorRestAdapterMock;
+
+    @Mock
+    private SimulatorWebServiceConfigurationProperties simulatorWebServiceConfigurationPropertiesMock;
+
+    @Mock
+    private SimulatorWebServiceAdapter simulatorWebServiceAdapterMock;
+
+    private SimulationMappings fixture;
+
+    @BeforeEach
+    void beforeEachSetup() {
+        fixture = new SimulationMappings(simulatorRestConfigurationPropertiesMock, simulatorRestAdapterMock, simulatorWebServiceConfigurationPropertiesMock, simulatorWebServiceAdapterMock);
+    }
+
+    @Nested
+    class GetServletMappingsTest {
+
+        @Test
+        void shouldReturnEmptyListWhenNoWebServiceAdapterAndPropertiesAreNull() {
+            fixture = new SimulationMappings(null, null, null, null);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenWebServicePropertiesIsNull() {
+            fixture = new SimulationMappings(null, null, null, simulatorWebServiceAdapterMock);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnServletMappingsFromAdapterWhenBothAdapterAndPropertiesArePresent() {
+            List<String> expectedMappings = List.of("/soap", "/ws");
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getServletMappings())
+                .isEqualTo(expectedMappings);
+        }
+
+        @Test
+        void shouldReturnEmptyListFromAdapterWhenAdapterReturnsNull() {
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(null);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnServletMappingsFromPropertiesWhenAdapterReturnsNullButPropertiesHaveMappings() {
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(null);
+            List<String> expectedMappings = List.of("/service");
+            when(simulatorWebServiceConfigurationPropertiesMock.getServletMappings())
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getServletMappings())
+                .isEqualTo(expectedMappings);
+        }
+
+        @Test
+        void shouldReturnServletMappingsFromPropertiesWhenAdapterIsNull() {
+            fixture = new SimulationMappings(null, null, simulatorWebServiceConfigurationPropertiesMock, null);
+            List<String> expectedMappings = List.of("/webservice");
+            when(simulatorWebServiceConfigurationPropertiesMock.getServletMappings())
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getServletMappings())
+                .isEqualTo(expectedMappings);
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenPropertiesHaveNullServletMappings() {
+            fixture = new SimulationMappings(null, null, simulatorWebServiceConfigurationPropertiesMock, null);
+            when(simulatorWebServiceConfigurationPropertiesMock.getServletMappings())
+                .thenReturn(null);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnMultipleServletMappingsFromAdapter() {
+            List<String> expectedMappings = new ArrayList<>();
+            expectedMappings.add("/soap/endpoint1");
+            expectedMappings.add("/soap/endpoint2");
+            expectedMappings.add("/ws/secure");
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getServletMappings())
+                .hasSize(3)
+                .isEqualTo(expectedMappings);
+        }
+    }
+
+    @Nested
+    class GetUrlMappingsTest {
+
+        @Test
+        void shouldReturnEmptyListWhenNoRestAdapterAndPropertiesAreNull() {
+            fixture = new SimulationMappings(null, null, null, null);
+
+            assertThat(fixture.getUrlMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenRestPropertiesIsNull() {
+            fixture = new SimulationMappings(null, simulatorRestAdapterMock, null, null);
+
+            assertThat(fixture.getUrlMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnUrlMappingsFromAdapterWhenBothAdapterAndPropertiesArePresent() {
+            List<String> expectedMappings = List.of("/api/v1", "/rest");
+            when(simulatorRestAdapterMock.urlMappings(simulatorRestConfigurationPropertiesMock))
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getUrlMappings())
+                .isEqualTo(expectedMappings);
+        }
+
+        @Test
+        void shouldReturnUrlMappingsFromPropertiesWhenAdapterIsNull() {
+            fixture = new SimulationMappings(simulatorRestConfigurationPropertiesMock, null, null, null);
+            List<String> expectedMappings = List.of("/resource");
+            when(simulatorRestConfigurationPropertiesMock.getUrlMappings())
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getUrlMappings())
+                .isEqualTo(expectedMappings);
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenPropertiesHaveNullUrlMappings() {
+            fixture = new SimulationMappings(simulatorRestConfigurationPropertiesMock, null, null, null);
+            when(simulatorRestConfigurationPropertiesMock.getUrlMappings())
+                .thenReturn(null);
+
+            assertThat(fixture.getUrlMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldReturnMultipleUrlMappingsFromAdapter() {
+            List<String> expectedMappings = new ArrayList<>();
+            expectedMappings.add("/api/users");
+            expectedMappings.add("/api/products");
+            expectedMappings.add("/api/orders");
+            when(simulatorRestAdapterMock.urlMappings(simulatorRestConfigurationPropertiesMock))
+                .thenReturn(expectedMappings);
+
+            assertThat(fixture.getUrlMappings())
+                .hasSize(3)
+                .isEqualTo(expectedMappings)
+                .containsExactly("/api/users", "/api/products", "/api/orders");
+        }
+
+        @Test
+        void shouldReturnUrlMappingsFromAdapterWhenBothAdapterAndPropertiesPresent() {
+            List<String> adapterMappings = List.of("/api/v2", "/custom");
+            when(simulatorRestAdapterMock.urlMappings(simulatorRestConfigurationPropertiesMock))
+                .thenReturn(adapterMappings);
+            List<String> propertiesMappings = List.of("/fallback");
+            lenient().
+                when(simulatorRestConfigurationPropertiesMock.getUrlMappings())
+                .thenReturn(propertiesMappings);
+
+            assertThat(fixture.getUrlMappings())
+                .isEqualTo(adapterMappings)
+                .containsExactly("/api/v2", "/custom");
+
+            verify(simulatorRestConfigurationPropertiesMock, never()).getUrlMappings();
+        }
+    }
+
+    @Nested
+    class CombinedMappingTests {
+
+        @Test
+        void shouldReturnBothServletAndUrlMappings() {
+            List<String> servletMappings = List.of("/soap");
+            List<String> urlMappings = List.of("/api");
+
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(servletMappings);
+            when(simulatorRestAdapterMock.urlMappings(simulatorRestConfigurationPropertiesMock))
+                .thenReturn(urlMappings);
+
+            assertThat(fixture.getServletMappings())
+                .isEqualTo(servletMappings)
+                .containsExactly("/soap");
+
+            assertThat(fixture.getUrlMappings())
+                .isEqualTo(urlMappings)
+                .containsExactly("/api");
+        }
+
+        @Test
+        void shouldHandleEmptyListsFromAdapters() {
+            List<String> emptyList = new ArrayList<>();
+            when(simulatorWebServiceAdapterMock.servletMappings(simulatorWebServiceConfigurationPropertiesMock))
+                .thenReturn(emptyList);
+            when(simulatorRestAdapterMock.urlMappings(simulatorRestConfigurationPropertiesMock))
+                .thenReturn(emptyList);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+
+            assertThat(fixture.getUrlMappings())
+                .isEmpty();
+        }
+
+        @Test
+        void shouldHandleNullsGracefullyAcrossAllComponents() {
+            fixture = new SimulationMappings(null, null, null, null);
+
+            assertThat(fixture.getServletMappings())
+                .isEmpty();
+
+            assertThat(fixture.getUrlMappings())
+                .isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
should allow "consumers" (someone extending the simulator) to access all URL mappings.

- [ ] sign commit