### PR TITLE
fix(citrus-spring-boot-simulator): delete all test result relationships first

### DIFF
--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/repository/TestResultRepository.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -54,4 +55,32 @@ public interface TestResultRepository extends JpaRepository<TestResult, Long>, J
     @Query("FROM TestResult WHERE id IN :testResultIds")
     @EntityGraph(attributePaths = {"testParameters"})
     List<TestResult> findAllWhereIdIn(@Param("testResultIds") List<Long> testResultIds, Sort sort);
+
+    @Modifying
+    @Query("DELETE FROM MessageHeader mh WHERE mh.message IN (SELECT m FROM Message m WHERE m.scenarioExecution IN (SELECT se FROM ScenarioExecution se WHERE se.testResult IS NOT NULL))")
+    void deleteAllMessageHeadersLinkedToTestResults();
+
+    @Modifying
+    @Query("DELETE FROM Message m WHERE m.scenarioExecution IN (SELECT se FROM ScenarioExecution se WHERE se.testResult IS NOT NULL)")
+    void deleteAllMessagesLinkedToTestResults();
+
+    @Modifying
+    @Query("DELETE FROM ScenarioAction sa WHERE sa.scenarioExecution IN (SELECT se FROM ScenarioExecution se WHERE se.testResult IS NOT NULL)")
+    void deleteAllScenarioActionsLinkedToTestResults();
+
+    @Modifying
+    @Query("DELETE FROM ScenarioParameter sp WHERE sp.scenarioExecution IN (SELECT se FROM ScenarioExecution se WHERE se.testResult IS NOT NULL)")
+    void deleteAllScenarioParametersLinkedToTestResults();
+
+    @Modifying
+    @Query("DELETE FROM ScenarioExecution se WHERE se.testResult IS NOT NULL")
+    void deleteAllScenarioExecutionsLinkedToTestResults();
+
+    @Modifying
+    @Query("DELETE FROM TestParameter")
+    void deleteAllTestParameters();
+
+    @Modifying
+    @Query("DELETE FROM TestResult")
+    void deleteAllTestResultsInBulk();
 }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/TestResultServiceImpl.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/service/impl/TestResultServiceImpl.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
+
 /**
  * Service Implementation for managing {@link org.citrusframework.simulator.model.TestResult}.
  */
@@ -72,8 +74,15 @@ public class TestResultServiceImpl implements TestResultService {
     }
 
     @Override
+    @Transactional(isolation = SERIALIZABLE)
     public void deleteAll() {
         logger.debug("Request to delete all TestResults");
-        testResultRepository.deleteAll();
+        testResultRepository.deleteAllMessageHeadersLinkedToTestResults();
+        testResultRepository.deleteAllMessagesLinkedToTestResults();
+        testResultRepository.deleteAllScenarioActionsLinkedToTestResults();
+        testResultRepository.deleteAllScenarioParametersLinkedToTestResults();
+        testResultRepository.deleteAllScenarioExecutionsLinkedToTestResults();
+        testResultRepository.deleteAllTestParameters();
+        testResultRepository.deleteAllTestResultsInBulk();
     }
 }

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/TestResultServiceImplTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/service/impl/TestResultServiceImplTest.java
@@ -95,6 +95,13 @@ class TestResultServiceImplTest {
     @Test
     void delete() {
         fixture.deleteAll();
-        verify(testResultRepositoryMock).deleteAll();
+
+        verify(testResultRepositoryMock).deleteAllMessageHeadersLinkedToTestResults();
+        verify(testResultRepositoryMock).deleteAllMessagesLinkedToTestResults();
+        verify(testResultRepositoryMock).deleteAllScenarioActionsLinkedToTestResults();
+        verify(testResultRepositoryMock).deleteAllScenarioParametersLinkedToTestResults();
+        verify(testResultRepositoryMock).deleteAllScenarioExecutionsLinkedToTestResults();
+        verify(testResultRepositoryMock).deleteAllTestParameters();
+        verify(testResultRepositoryMock).deleteAllTestResultsInBulk();
     }
 }


### PR DESCRIPTION
Prevents OOM exceptions during test-result DELETE. Hibernate previously created SELECT queries for foreign keys.

Isolation level SERIALIZABLE prevents phantom reads, so no concurrent insert into TestResult can commit while the transaction is in flight.