### PR TITLE
prevent memory leak from uncleaned futures

### DIFF
--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapter.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapter.java
@@ -24,6 +24,7 @@ import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
 import org.citrusframework.simulator.correlation.CorrelationHandler;
 import org.citrusframework.simulator.correlation.CorrelationHandlerRegistry;
 import org.citrusframework.simulator.exception.SimulatorException;
+import org.citrusframework.simulator.scenario.ScenarioEndpoint;
 import org.citrusframework.simulator.scenario.SimulatorScenario;
 import org.citrusframework.simulator.service.ScenarioExecutorService;
 import org.slf4j.Logger;
@@ -81,7 +82,7 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
         CompletableFuture<Message> responseFuture = new CompletableFuture<>();
         handler.getScenarioEndpoint().add(request, responseFuture);
 
-        return awaitResponseOrThrowException(responseFuture, handler.getScenarioEndpoint().getName());
+        return awaitResponseOrThrowException(responseFuture, handler.getScenarioEndpoint().getName(), handler.getScenarioEndpoint());
     }
 
     @Override
@@ -103,13 +104,14 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
         try {
             scenarioExecutorService.run(scenario, scenarioName, emptyList());
         } catch (Exception e) {
+            scenario.getScenarioEndpoint().cancel(responseFuture);
             throw getResponseStatusException(e);
         }
 
-        return awaitResponseOrThrowException(responseFuture, scenarioName);
+        return awaitResponseOrThrowException(responseFuture, scenarioName, scenario.getScenarioEndpoint());
     }
 
-    private Message awaitResponseOrThrowException(CompletableFuture<Message> responseFuture, String scenarioName) {
+    private Message awaitResponseOrThrowException(CompletableFuture<Message> responseFuture, String scenarioName, ScenarioEndpoint scenarioEndpoint) {
         try {
             if (handleResponse) {
                 var message = responseFuture.get(simulatorConfiguration.getDefaultTimeout(), MILLISECONDS);
@@ -123,12 +125,15 @@ public class SimulatorEndpointAdapter extends RequestDispatchingEndpointAdapter 
                 return null;
             }
         } catch (TimeoutException e) {
+            scenarioEndpoint.cancel(responseFuture);
             logger.warn("No response for scenario '{}'", scenarioName);
             return null;
         } catch (InterruptedException e) {
+            scenarioEndpoint.cancel(responseFuture);
             currentThread().interrupt();
             throw new SimulatorException(e);
         } catch (ExecutionException e) {
+            scenarioEndpoint.cancel(responseFuture);
             throw new SimulatorException(e);
         }
     }

--- a/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/ScenarioEndpoint.java
+++ b/simulator-spring-boot/src/main/java/org/citrusframework/simulator/scenario/ScenarioEndpoint.java
@@ -61,7 +61,7 @@ public class ScenarioEndpoint extends AbstractEndpoint implements Producer, Cons
 
     /**
      * FIFO queue of futures in arrival order, used by {@link #fail} which has no TestContext.
-     * Populated in {@link #receive}; may already be completed by {@link #send} when consumed.
+     * Populated in {@link #add}; may already be completed by {@link #send} when consumed.
      */
     private final Queue<CompletableFuture<Message>> orderedFutures = new LinkedBlockingQueue<>();
 
@@ -83,6 +83,34 @@ public class ScenarioEndpoint extends AbstractEndpoint implements Producer, Cons
         pendingFutures.put(request, future);
         channel.add(request);
         orderedFutures.add(future);
+    }
+
+    /**
+     * Removes an in-flight response future from all internal collections.
+     *
+     * @param future future to remove
+     */
+    public void cancel(CompletableFuture<Message> future) {
+        if (isNull(future)) {
+            return;
+        }
+
+        orderedFutures.remove(future);
+
+        synchronized (pendingFutures) {
+            pendingFutures.entrySet().removeIf(entry -> {
+                if (entry.getValue() == future) {
+                    channel.removeIf(message -> message == entry.getKey());
+                    return true;
+                }
+
+                return false;
+            });
+        }
+
+        synchronized (activeFutures) {
+            activeFutures.entrySet().removeIf(entry -> entry.getValue() == future);
+        }
     }
 
     @Override
@@ -133,14 +161,9 @@ public class ScenarioEndpoint extends AbstractEndpoint implements Producer, Cons
     }
 
     void fail(Throwable e) {
-        // Clean up any unreceived message lingering in the channel
-        Message unreceived = channel.poll();
-        if (nonNull(unreceived)) {
-            pendingFutures.remove(unreceived);
-        }
-
         CompletableFuture<Message> future = orderedFutures.poll();
         if (nonNull(future)) {
+            cancel(future);
             future.complete(new SimulationFailedUnexpectedlyException(e));
             return;
         }

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapterTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/endpoint/SimulatorEndpointAdapterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.simulator.endpoint;
+
+import org.citrusframework.message.Message;
+import org.citrusframework.simulator.config.SimulatorConfigurationProperties;
+import org.citrusframework.simulator.correlation.CorrelationHandlerRegistry;
+import org.citrusframework.simulator.exception.SimulatorException;
+import org.citrusframework.simulator.scenario.ScenarioEndpoint;
+import org.citrusframework.simulator.scenario.SimulatorScenario;
+import org.citrusframework.simulator.service.ScenarioExecutorService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class})
+class SimulatorEndpointAdapterTest {
+
+    private static final String SCENARIO_NAME = "testScenario";
+
+    @Mock
+    private ApplicationContext applicationContextMock;
+
+    @Mock
+    private CorrelationHandlerRegistry handlerRegistryMock;
+
+    @Mock
+    private ScenarioExecutorService scenarioExecutorServiceMock;
+
+    @Mock
+    private SimulatorConfigurationProperties simulatorConfigurationMock;
+
+    @Mock
+    private SimulatorScenario scenarioMock;
+
+    @Mock
+    private ScenarioEndpoint scenarioEndpointMock;
+
+    @Mock
+    private Message requestMessageMokc;
+
+    @AfterEach
+    void clearInterruptedStatus() {
+        if (Thread.interrupted()) {
+            // Clear interrupted status to avoid spilling over between tests.
+        }
+    }
+
+    @Nested
+    class DispatchMessageTest {
+        @Test
+        void shouldCancelFuture_onTimeout() {
+            var fixture = createFixture();
+
+            when(simulatorConfigurationMock.getDefaultTimeout()).thenReturn(1L);
+
+            fixture.dispatchMessage(requestMessageMokc, SCENARIO_NAME);
+
+            verify(scenarioEndpointMock).cancel(anyFuture());
+        }
+
+        @Test
+        void shouldCancelFuture_onExecutionException() {
+            var fixture = createFixture();
+            var responseFutureRef = new AtomicReference<CompletableFuture<Message>>();
+
+            when(simulatorConfigurationMock.getDefaultTimeout()).thenReturn(50L);
+            doAnswer(invocation -> {
+                responseFutureRef.set(invocation.getArgument(1));
+                return null;
+            }).when(scenarioEndpointMock).add(eq(requestMessageMokc), anyFuture());
+            doAnswer(invocation -> {
+                responseFutureRef.get().completeExceptionally(new IllegalStateException("boom"));
+                return null;
+            }).when(scenarioExecutorServiceMock).run(eq(scenarioMock), eq(SCENARIO_NAME), anyList());
+
+            assertThatThrownBy(() -> fixture.dispatchMessage(requestMessageMokc, SCENARIO_NAME))
+                .isInstanceOf(SimulatorException.class);
+
+            verify(scenarioEndpointMock).cancel(responseFutureRef.get());
+        }
+
+        @Test
+        void shouldCancelFuture_onInterruptedException() {
+            var fixture = createFixture();
+
+            when(simulatorConfigurationMock.getDefaultTimeout()).thenReturn(50L);
+            doAnswer(invocation -> {
+                Thread.currentThread().interrupt();
+                return null;
+            }).when(scenarioExecutorServiceMock).run(eq(scenarioMock), eq(SCENARIO_NAME), anyList());
+
+            assertThatThrownBy(() -> fixture.dispatchMessage(requestMessageMokc, SCENARIO_NAME))
+                .isInstanceOf(SimulatorException.class);
+
+            verify(scenarioEndpointMock).cancel(anyFuture());
+        }
+
+        @Test
+        void shouldCancelFuture_onSynchronousRunFailure() {
+            var fixture = createFixture();
+
+            doThrow(new IllegalStateException("sync-run-failed"))
+                .when(scenarioExecutorServiceMock).run(eq(scenarioMock), eq(SCENARIO_NAME), anyList());
+
+            assertThatThrownBy(() -> fixture.dispatchMessage(requestMessageMokc, SCENARIO_NAME))
+                .isInstanceOf(ResponseStatusException.class);
+
+            verify(scenarioEndpointMock).cancel(anyFuture());
+        }
+
+        private SimulatorEndpointAdapter createFixture() {
+            when(applicationContextMock.containsBean(SCENARIO_NAME)).thenReturn(true);
+            when(applicationContextMock.getBean(SCENARIO_NAME, SimulatorScenario.class)).thenReturn(scenarioMock);
+            when(scenarioMock.getScenarioEndpoint()).thenReturn(scenarioEndpointMock);
+
+            return new SimulatorEndpointAdapter(applicationContextMock, handlerRegistryMock, scenarioExecutorServiceMock, simulatorConfigurationMock);
+        }
+
+        private static CompletableFuture<Message> anyFuture() {
+            return any();
+        }
+    }
+}

--- a/simulator-spring-boot/src/test/java/org/citrusframework/simulator/scenario/ScenarioEndpointTest.java
+++ b/simulator-spring-boot/src/test/java/org/citrusframework/simulator/scenario/ScenarioEndpointTest.java
@@ -154,6 +154,38 @@ class ScenarioEndpointTest {
             verifyNoMoreInteractions(params.responseFuture1(), params.responseFuture2());
         }
 
+        @Test
+        void shouldRemoveActiveFutureAfterReceive() {
+            var testContext = mockTestContext();
+            var request = mock(Message.class);
+            CompletableFuture<Message> responseFuture = mock();
+
+            fixture.add(request, responseFuture);
+            fixture.receive(testContext);
+
+            fixture.fail(mock(Throwable.class));
+
+            assertThatThrownBy(() -> fixture.send(mock(Message.class), testContext))
+                .isInstanceOf(SimulatorException.class)
+                .hasMessage("Failed to process scenario response message - missing response consumer!");
+        }
+    }
+
+    @Nested
+    class CancelTest {
+
+        @Test
+        void shouldRemovePendingFutureFromCollections() {
+            var request = mock(Message.class);
+            CompletableFuture<Message> responseFuture = mock();
+            fixture.add(request, responseFuture);
+
+            fixture.cancel(responseFuture);
+
+            assertThatThrownBy(() -> fixture.fail(new CitrusRuntimeException()))
+                .isInstanceOf(SimulatorException.class)
+                .hasMessage("Failed to receive scenario inbound message");
+        }
     }
 
     @Nested


### PR DESCRIPTION
Timed-out and failed requests left `CompletableFuture`, `HttpMessage`,
and `LinkedBlockingQueue$Node` instances permanently in `ScenarioEndpoint`'s internal collections, causing unbounded heap growth.

- Add `ScenarioEndpoint.cancel()` to remove a future from all internal collections (`orderedFutures`, `pendingFutures`, `channel`, `activeFutures`)
- Call `cancel()` in `SimulatorEndpointAdapter` on `TimeoutException`, `InterruptedException`, `ExecutionException`, and synchronous `run()` failure
- Fix `fail()` to clean up activeFutures after `receive()` was already called, closing the "received-then-failed" leak path